### PR TITLE
sparse matrix vector multi atol and rtol from 1e-5 -> 1e-3

### DIFF
--- a/challenges/medium/18_sparse_matrix_vector_multiplication/challenge.py
+++ b/challenges/medium/18_sparse_matrix_vector_multiplication/challenge.py
@@ -7,8 +7,8 @@ class Challenge(ChallengeBase):
     def __init__(self):
         super().__init__(
             name="Sparse Matrix-Vector Multiplication",
-            atol=1e-05,
-            rtol=1e-05,
+            atol=1e-03,
+            rtol=1e-03,
             num_gpus=1,
             access_tier="free"
         )


### PR DESCRIPTION
Hi, change for the atol and rtol for sparse matrix vector multi.
Now for a simple solution that can pass before is failed to pass.
Origin code from the solution section of the problem.
```c++
#include "solve.h"
#include <cuda_runtime.h>

const int BLOCK_SIZE = 16;

__global__ void kernel(const float* A, const float* x, float* y, int M, int N){
    int row = blockDim.y * blockIdx.y + threadIdx.y;
    int col = blockDim.x * blockIdx.x + threadIdx.x;
    if(row < M && col < 1){
        float total = 0;
        for(int i = 0; i < N; i++) total += A[row * N + i] * x[i * 1 + col];
        y[row + col] = total;
    }
}

// A, x, y are device pointers
void solve(const float* A, const float* x, float* y, int M, int N, int nnz) {
    dim3 thread_dim(BLOCK_SIZE, BLOCK_SIZE);
    dim3 block_dim((1 + BLOCK_SIZE - 1) / BLOCK_SIZE, (M + BLOCK_SIZE - 1) / BLOCK_SIZE);
    kernel <<<block_dim, thread_dim>>>(A, x, y, M, N); 
} 
```