### PR TITLE
[Rainbow Table] Fix FNV-1a kernel by initializing hash_val as vector

### DIFF
--- a/challenges/easy/24_rainbow_table/starter/starter.triton.py
+++ b/challenges/easy/24_rainbow_table/starter/starter.triton.py
@@ -7,7 +7,7 @@ def fnv1a_hash(x):
     FNV_PRIME = 16777619
     OFFSET_BASIS = 2166136261
     
-    hash_val = OFFSET_BASIS
+    hash_val = tl.full(x.shape, OFFSET_BASIS, tl.uint32)
     
     for byte_pos in range(4):
         byte = (x >> (byte_pos * 8)) & 0xFF


### PR DESCRIPTION
Previously, hash_val was initialized as a scalar (hash_val = OFFSET_BASIS),
which caused incorrect behavior in the Triton kernel when processing multiple
elements per thread block. 

This PR fixes the issue by initializing hash_val as a vector using
tl.full, matching the shape of the input block. This ensures that each element
in the block has the correct initial hash value.