### PR TITLE
[bug]: fix max subarray sum

### DIFF
--- a/challenges/medium/51_max_subarray_sum/challenge.py
+++ b/challenges/medium/51_max_subarray_sum/challenge.py
@@ -36,7 +36,7 @@ class Challenge(ChallengeBase):
             current_sum += input[i] - input[i - window_size]
     
             # Update max_sum if the current sum is greater
-            max_sum = max(max_sum, current_sum)
+            max_sum = torch.max(max_sum, current_sum)
 
         # Store the final result in the output tensor
         output[0] = max_sum


### PR DESCRIPTION
Problem：https://leetgpu.com/challenges/max-subarray-sum

<img width="2232" height="734" alt="32e078ba-c2b3-4593-aafb-9c918c64cc31" src="https://github.com/user-attachments/assets/404f100e-edec-4bcd-8d90-875e05666c8b" />


```
input = [1, 2, 4, 2, 3]
N = 5
window_size = 2
Test failed! Here are the inputs:
input = [1, 2, 4, 2, 3]
N = 5
window_size = 2
Mismatch in 'output'
Expected: [5]
Got: [6]
Max abs diff: 1
```