### PR TITLE
[RMS Normalization] challenge use N = 100000 but description is 10,000

### DIFF
--- a/challenges/medium/50_rms_normalization/challenge.html
+++ b/challenges/medium/50_rms_normalization/challenge.html
@@ -40,7 +40,7 @@ Output: output = [0.46290955, 0.9258191, 1.3887286]
 
 <h2>Constraints</h2>
 <ul>
-  <li>1 ≤ <code>N</code> ≤ 10,000</li>
+  <li>1 ≤ <code>N</code> ≤ 100,000</li>
   <li><code>eps</code> = 1e-5</li>
   <li>-100.0 ≤ input values ≤ 100.0</li>
   <li>0.1 ≤ gamma ≤ 10.0</li>


### PR DESCRIPTION
[challenge.py:137](https://github.com/AlphaGPU/leetgpu-challenges/blob/9d935514467a489bd69e91498b071aa4cba2751c/challenges/medium/50_rms_normalization/challenge.py#L137) use N = 100000 but [challenge.html:43](https://github.com/AlphaGPU/leetgpu-challenges/blob/9d935514467a489bd69e91498b071aa4cba2751c/challenges/medium/50_rms_normalization/challenge.html#L43) is 10,000