### PR TITLE
[Feat] CI workflow: Check whether submitted challenges have duplicated Questions

### DIFF
--- a/.github/workflows/check_duplicated_index.yml
+++ b/.github/workflows/check_duplicated_index.yml
@@ -18,9 +18,6 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Install dependencies
-      run: pip install pyyaml
-
     - name: Check for duplicate indexes
       run: |
         python - << 'EOF'


### PR DESCRIPTION
Duplicated questions can cause issues in LeetGPU, such as conflicting question templates and incorrect solution statistics showing up under the same index. To prevent this, we need a CI workflow that automatically detects duplicate questions before any PR is merged.