### PR TITLE
[Feat] Check Duplicated Indexs CI before deployment

### DIFF
--- a/.github/workflows/check_duplicated_index.yml
+++ b/.github/workflows/check_duplicated_index.yml
@@ -1,7 +1,7 @@
 name: Check Challenge Indexes
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'challenges/**'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-duplicated-index:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Check for duplicate indexes
+        run: |
+          python - << 'EOF'
+          import os
+          import collections
+
+          challenges_dir = "challenges"
+
+          questions = collections.defaultdict(list)
+          for folder in os.listdir(challenges_dir):
+              folder_path = os.path.join(challenges_dir, folder)
+              for question in os.listdir(folder_path):
+                  idx = question.split("_")[0]
+                  questions[idx].append(question)
+                  if len(questions[idx]) > 1:
+                      print(f"PR duplicated found: \n {questions[idx]}.")
+                      exit(1)
+          print("✅ All indexes are unique.")
+          EOF
   update-pset:
     runs-on: ubuntu-latest
+    needs: check-duplicated-index
 
     steps:
       - name: Set up Python


### PR DESCRIPTION
1. Modify _pull_request_ in  **check_duplicated_index**  to _pull_request_target_. because the goal is to prevent duplication in the branch we are merging into (the main branch).

2. We also need to check check_duplicated_indexs before deployment because if the main branch is updated, the **check_duplicated_index** in a PR will not run again to verify whether duplication exists. Adding this check before any deployment is a safer approach to avoid duplication, rather than creating a new workflow for every PR when the main branch is updated.
