### PR TITLE
Fix 43 Count Array Element performance test

### DIFF
--- a/challenges/easy/43_count_array_element/challenge.py
+++ b/challenges/easy/43_count_array_element/challenge.py
@@ -105,5 +105,5 @@ class Challenge(ChallengeBase):
             "input": input,
             "output": output,
             "N": 100000000,
-            "K": 501010,
+            "K": 51010,
         }


### PR DESCRIPTION
Change the K value from 501010 to 51010 so that it's in the input range of 1 to 100,000. Right now the answer to the performance test is always 0 since K is never in the input.

Note that K is still extremely sparse in the input, so that naive solutions are still likely to outperform a standard reduction. Since this is an Easy problem maybe that's ok. If not, a better performance test is needed.