### PR TITLE
Fix fork PR checkout v2

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,9 +26,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
-          # Get fork info and add as fetch URL so action can find the branch
-          FORK_URL=$(gh pr view $PR_NUMBER --json headRepositoryOwner,headRepository -q '"https://github.com/\(.headRepositoryOwner.login)/\(.headRepository.name).git"')
-          git remote set-url --add origin "$FORK_URL"
+          # Check if PR is from a fork
+          IS_FORK=$(gh pr view $PR_NUMBER --json isCrossRepository -q .isCrossRepository)
+          if [ "$IS_FORK" = "true" ]; then
+            # Replace origin URL with fork URL so action can fetch the branch
+            FORK_URL=$(gh pr view $PR_NUMBER --json headRepositoryOwner,headRepository -q '"https://github.com/\(.headRepositoryOwner.login)/\(.headRepository.name).git"')
+            git remote set-url origin "$FORK_URL"
+          fi
           gh pr checkout $PR_NUMBER
 
       - name: Run Claude Code Review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,9 +31,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           PR_NUMBER=${{ github.event.issue.number }}
-          # Get fork info and add as fetch URL so action can find the branch
-          FORK_URL=$(gh pr view $PR_NUMBER --json headRepositoryOwner,headRepository -q '"https://github.com/\(.headRepositoryOwner.login)/\(.headRepository.name).git"')
-          git remote set-url --add origin "$FORK_URL"
+          # Check if PR is from a fork
+          IS_FORK=$(gh pr view $PR_NUMBER --json isCrossRepository -q .isCrossRepository)
+          if [ "$IS_FORK" = "true" ]; then
+            # Replace origin URL with fork URL so action can fetch the branch
+            FORK_URL=$(gh pr view $PR_NUMBER --json headRepositoryOwner,headRepository -q '"https://github.com/\(.headRepositoryOwner.login)/\(.headRepository.name).git"')
+            git remote set-url origin "$FORK_URL"
+          fi
           gh pr checkout $PR_NUMBER
 
       - name: Run Claude Code


### PR DESCRIPTION
## Summary
- For fork PRs, **replace** origin URL with fork URL (not just add)
- This ensures `git fetch origin <branch>` succeeds because origin now points to the fork

Previous approach (adding fork URL) didn't work because git still failed to find the branch on the original origin URL.

## Test plan
- [ ] Test on fork PR #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)