### PR TITLE
Fix starters for Weight Dequantization Problem

### DIFF
--- a/challenges/medium/64_weight_dequantization/starter/starter.cute.py
+++ b/challenges/medium/64_weight_dequantization/starter/starter.cute.py
@@ -4,5 +4,5 @@ import cutlass.cute as cute
 
 # X, S, Y are tensors on the GPU
 @cute.jit
-def solve(X: cute.Tensor, S: cute.Tensor, Y: cute.Tensor, TILE_SIZE: cute.Int32):
+def solve(X: cute.Tensor, S: cute.Tensor, Y: cute.Tensor, M: cute.Int32, N: cute.Int32, TILE_SIZE: cute.Int32):
     pass

--- a/challenges/medium/64_weight_dequantization/starter/starter.mojo
+++ b/challenges/medium/64_weight_dequantization/starter/starter.mojo
@@ -5,5 +5,5 @@ from math import ceildiv
 
 # X, S, Y are device pointers
 @export
-def solve(X: UnsafePointer[Float32], S: UnsafePointer[Float32], Y: UnsafePointer[Float32], TILE_SIZE: Int32):
+def solve(X: UnsafePointer[Float32], S: UnsafePointer[Float32], Y: UnsafePointer[Float32], M: Int32, N: Int32, TILE_SIZE: Int32):
     pass

--- a/challenges/medium/64_weight_dequantization/starter/starter.pytorch.py
+++ b/challenges/medium/64_weight_dequantization/starter/starter.pytorch.py
@@ -2,5 +2,5 @@ import torch
 
 
 # X, S, Y are tensors on the GPU
-def solve(X: torch.Tensor, S: torch.Tensor, Y: torch.Tensor, TILE_SIZE: int):
+def solve(X: torch.Tensor, S: torch.Tensor, Y: torch.Tensor, M: int, N: int, TILE_SIZE: int):
     pass

--- a/challenges/medium/64_weight_dequantization/starter/starter.triton.py
+++ b/challenges/medium/64_weight_dequantization/starter/starter.triton.py
@@ -4,5 +4,5 @@ import triton.language as tl
 
 
 # X, S, Y are tensors on the GPU
-def solve(X: torch.Tensor, S: torch.Tensor, Y: torch.Tensor, TILE_SIZE: int):
+def solve(X: torch.Tensor, S: torch.Tensor, Y: torch.Tensor, M: int, N: int, TILE_SIZE: int):
     pass


### PR DESCRIPTION
The starter code for the [Weight Dequantization](https://leetgpu.com/challenges/weight-dequantization) problem has an incorrect function signature that doesn't match the test runner's expectations

```python
# current
def solve(X: torch.Tensor, S: torch.Tensor, Y: torch.Tensor, TILE_SIZE: int):
    pass 

# vs expected
def solve(X: torch.Tensor, S: torch.Tensor, Y: torch.Tensor, M: int, N: int, TILE_SIZE: int):
    pass
```

To reproduce the issue (e.g. in Pytorch) submit the default starter code to see the error "TypeError: solve() takes 4 positional arguments but 6 were given. Test case failed"

Users must manually fix the function signature before being able to test their solution. While this is a minor fix, it creates confusion and breaks the out-of-box experience. 

**What I've done:** I've updated starter code for Pytorch, Cute, Mojo, and Triton to include the missing M and N parameters. After quickly reviewing the eval code, I believe they share the same call signature. I also verified from the user side and testing confirmed the runner does pass 6 arguments in all cases. However, I have not thoroughly audited the entire codebase - please verify no other dependencies are affected by this change.

---

P.S. Submitting the unmodified starter explicitly crashes in Pytorch, Cute, and Triton. Mojo doesn't crash with the wrong signature, so I verified it separately by printing the arguments:
```mojo
@export
fn solve(X: UnsafePointer[Float32], S: UnsafePointer[Float32], Y: UnsafePointer[Float32], M: Int32, N: Int32, TILE_SIZE: Int32) raises:
    print("M=", M, "N=", N, "TILE=", TILE_SIZE)
```