### PR TITLE
Fix Jacobi stencil challenge formula rendering

### DIFF
--- a/challenges/medium/69_jacobi_stencil_2d/challenge.html
+++ b/challenges/medium/69_jacobi_stencil_2d/challenge.html
@@ -28,14 +28,14 @@ Output (4 &times; 4):
 13.0  14.0  15.0  16.0
 </pre>
 <p>
-  Interior cell (1,1): 0.25 &times; (input[0,1] + input[2,1] + input[1,0] + input[1,2])
-  = 0.25 &times; (2.0 + 10.0 + 5.0 + 7.0) = 6.0<br>
-  Interior cell (1,2): 0.25 &times; (input[0,2] + input[2,2] + input[1,1] + input[1,3])
-  = 0.25 &times; (3.0 + 11.0 + 6.0 + 8.0) = 7.0<br>
-  Interior cell (2,1): 0.25 &times; (input[1,1] + input[3,1] + input[2,0] + input[2,2])
-  = 0.25 &times; (6.0 + 14.0 + 9.0 + 11.0) = 10.0<br>
-  Interior cell (2,2): 0.25 &times; (input[1,2] + input[3,2] + input[2,1] + input[2,3])
-  = 0.25 &times; (7.0 + 15.0 + 10.0 + 12.0) = 11.0
+  Interior cell (1,1): \(0.25 \times (\text{input}[0,1] + \text{input}[2,1] + \text{input}[1,0] + \text{input}[1,2])\)
+  \(= 0.25 \times (2.0 + 10.0 + 5.0 + 7.0) = 6.0\)<br>
+  Interior cell (1,2): \(0.25 \times (\text{input}[0,2] + \text{input}[2,2] + \text{input}[1,1] + \text{input}[1,3])\)
+  \(= 0.25 \times (3.0 + 11.0 + 6.0 + 8.0) = 7.0\)<br>
+  Interior cell (2,1): \(0.25 \times (\text{input}[1,1] + \text{input}[3,1] + \text{input}[2,0] + \text{input}[2,2])\)
+  \(= 0.25 \times (6.0 + 14.0 + 9.0 + 11.0) = 10.0\)<br>
+  Interior cell (2,2): \(0.25 \times (\text{input}[1,2] + \text{input}[3,2] + \text{input}[2,1] + \text{input}[2,3])\)
+  \(= 0.25 \times (7.0 + 15.0 + 10.0 + 12.0) = 11.0\)
 </p>
 
 <h2>Constraints</h2>


### PR DESCRIPTION
## Summary
- Convert inline math formulas in the Jacobi stencil example from HTML entities (`&times;`) to LaTeX notation (`\(...\)`) so the site's math renderer properly typesets them

## Test plan
- [ ] Verify the challenge page renders the interior cell formulas correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)