### PR TITLE
Add challenge validation instructions to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -106,3 +106,11 @@ jobs:
 
             If this is NOT a fork PR (is_fork=false):
             - You can commit and push directly to the PR branch as normal
+
+            IMPORTANT - Challenge Validation:
+            When creating or reviewing PRs that add or modify challenges, you MUST validate them using run_challenge.py:
+            1. Write a correct CUDA solution in the challenge's solution/solution.cu directory
+            2. Run: python scripts/run_challenge.py <challenge_dir> --language cuda --action run
+            3. Verify all functional tests pass and the performance test completes
+            4. Do NOT commit the solution file to the PR
+            5. You may only run this script 5 times per session — verify your solution logic before submitting


### PR DESCRIPTION
## Summary
- Adds explicit instructions to the Claude Code CI prompt requiring it to validate challenges using `run_challenge.py`
- When creating or reviewing challenge PRs, Claude will now write a CUDA solution and run it against the platform before approving

## Context
Claude was skipping the `run_challenge.py` validation step during challenge reviews despite having access to the tool and env vars. The CLAUDE.md mentions it but the workflow prompt didn't, so the agent didn't prioritize it.

## Test plan
- [ ] Next challenge PR triggers Claude to write a solution and run `run_challenge.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)