### PR TITLE
Fix: Increase N for statistically significant performance benchmarking

### DIFF
--- a/challenges/medium/17_dot_product/challenge.html
+++ b/challenges/medium/17_dot_product/challenge.html
@@ -27,5 +27,5 @@
     <li><code>A</code> and <code>B</code> have identical lengths</li>
     <li>1 ≤ <code>N</code> ≤ 100,000,000</li>
 
-  <li>Performance is measured with <code>N</code> = 5</li>
+  <li>Performance is measured with <code>N</code> = 4194304</li>
 </ul>

--- a/challenges/medium/17_dot_product/challenge.py
+++ b/challenges/medium/17_dot_product/challenge.py
@@ -105,7 +105,7 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        N = 5
+        N = 4194304
         A = torch.empty(N, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
         B = torch.empty(N, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
         result = torch.zeros(1, device="cuda", dtype=dtype)


### PR DESCRIPTION
The former value of N for performance benchmarking is 5, and it results in many ridiculous benchmarking results.