### PR TITLE
fix(easy/rainbow-table): align hash helpers with uint32 iterative semantics

### DIFF
--- a/challenges/easy/24_rainbow_table/starter/starter.cu
+++ b/challenges/easy/24_rainbow_table/starter/starter.cu
@@ -1,13 +1,13 @@
 #include <cuda_runtime.h>
 
-__device__ unsigned int fnv1a_hash(int input) {
+__device__ unsigned int fnv1a_hash(unsigned int input) {
     const unsigned int FNV_PRIME = 16777619;
     const unsigned int OFFSET_BASIS = 2166136261;
 
     unsigned int hash = OFFSET_BASIS;
 
     for (int byte_pos = 0; byte_pos < 4; byte_pos++) {
-        unsigned char byte = (input >> (byte_pos * 8)) & 0xFF;
+        unsigned char byte = (input >> (byte_pos * 8)) & 0xFFu;
         hash = (hash ^ byte) * FNV_PRIME;
     }
 

--- a/challenges/easy/24_rainbow_table/starter/starter.cute.py
+++ b/challenges/easy/24_rainbow_table/starter/starter.cute.py
@@ -2,15 +2,14 @@ import cutlass
 import cutlass.cute as cute
 
 
-def fnv1a_hash_u32_scalar(x):
+def fnv1a_hash_u32_scalar(x: cute.Uint32) -> cute.Uint32:
     FNV_PRIME = 16777619
     OFFSET_BASIS = 2166136261
-    val = cute.Uint32(x)
     hash_val = cute.Uint32(OFFSET_BASIS)
     prime = cute.Uint32(FNV_PRIME)
     mask = cute.Uint32(0xFF)
     for byte_pos in range(4):
-        byte = (val >> (byte_pos * 8)) & mask
+        byte = (x >> (byte_pos * 8)) & mask
         hash_val = (hash_val ^ byte) * prime
     return cute.Uint32(hash_val)
 

--- a/challenges/easy/24_rainbow_table/starter/starter.jax.py
+++ b/challenges/easy/24_rainbow_table/starter/starter.jax.py
@@ -5,12 +5,11 @@ import jax.numpy as jnp
 def fnv1a_hash(x: jax.Array) -> jax.Array:
     FNV_PRIME = jnp.uint32(16777619)
     OFFSET_BASIS = jnp.uint32(2166136261)
-    x_u32 = x.astype(jnp.uint32)
-    hash_val = jnp.full_like(x_u32, OFFSET_BASIS, dtype=jnp.uint32)
+    hash_val = jnp.full_like(x, OFFSET_BASIS, dtype=jnp.uint32)
 
     MASK_FF = jnp.uint32(0xFF)
     for byte_pos in range(4):
-        byte = (x_u32 >> jnp.uint32(byte_pos * 8)) & MASK_FF
+        byte = (x >> jnp.uint32(byte_pos * 8)) & MASK_FF
         hash_val = hash_val ^ byte
         hash_val = hash_val * FNV_PRIME
 

--- a/challenges/easy/24_rainbow_table/starter/starter.mojo
+++ b/challenges/easy/24_rainbow_table/starter/starter.mojo
@@ -4,14 +4,14 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-def fnv1a_hash(input: Int32) -> UInt32:
+def fnv1a_hash(input: UInt32) -> UInt32:
     alias FNV_PRIME: UInt32 = 16777619
     alias OFFSET_BASIS: UInt32 = 2166136261
 
     var hash: UInt32 = OFFSET_BASIS
 
     for byte_pos in range(4):
-        var byte_val: UInt32 = UInt32((input >> (byte_pos * 8)) & 0xFF)
+        var byte_val: UInt32 = (input >> (byte_pos * 8)) & UInt32(0xFF)
         hash = (hash ^ byte_val) * FNV_PRIME
 
     return hash


### PR DESCRIPTION
## Summary 

Resolves #214. 

The Rainbow Table challenge requires R rounds of iterative hashing, meaning the output of one round feeds directly into the next. Several starter templates previously declared their `fnv1a_hash` helpers with signed integers or performed internal type casting, creating an inconsistent internal state. 

This PR ensures the hash helpers consistently operate on unsigned 32-bit integers, leaving initial type normalization to the caller. 

## Changes 

- **CUDA**: Changed `fnv1a_hash(int input)` to `unsigned int`. Used `0xFFu`. 
- **Mojo**: Changed `fnv1a_hash(input: Int32)` to `UInt32`. 
- **JAX / CuTe**: Removed internal type casting (`astype` / `cute.Uint32`) from the helper body. Added Python type hints to CuTe. 

*(Note: PyTorch uses `int64` to bypass missing `uint32` bitwise op support in the framework. Triton remains untyped per Triton DSL conventions. Both are left unchanged.)* 