### PR TITLE
Switch starter.mojo kernels and solve from fn to def

### DIFF
--- a/challenges/easy/19_reverse_array/starter/starter.mojo
+++ b/challenges/easy/19_reverse_array/starter/starter.mojo
@@ -4,13 +4,13 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn reverse_array_kernel(input: UnsafePointer[Float32, MutExternalOrigin], N: Int32):
+def reverse_array_kernel(input: UnsafePointer[Float32, MutExternalOrigin], N: Int32):
     pass
 
 
 # input is a device pointer (i.e. pointer to memory on the GPU)
 @export
-fn solve(input: UnsafePointer[Float32, MutExternalOrigin], N: Int32) raises:
+def solve(input: UnsafePointer[Float32, MutExternalOrigin], N: Int32) raises:
     var threadsPerBlock: Int32 = 256
     var ctx = DeviceContext()
 

--- a/challenges/easy/1_vector_add/starter/starter.mojo
+++ b/challenges/easy/1_vector_add/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn vector_add_kernel(
+def vector_add_kernel(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     C: UnsafePointer[Float32, MutExternalOrigin],
@@ -15,7 +15,7 @@ fn vector_add_kernel(
 
 # A, B, C are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     C: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/easy/21_relu/starter/starter.mojo
+++ b/challenges/easy/21_relu/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn relu_kernel(
+def relu_kernel(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,
@@ -14,7 +14,7 @@ fn relu_kernel(
 
 # input, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/easy/23_leaky_relu/starter/starter.mojo
+++ b/challenges/easy/23_leaky_relu/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn leaky_relu_kernel(
+def leaky_relu_kernel(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,
@@ -14,7 +14,7 @@ fn leaky_relu_kernel(
 
 # input, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/easy/24_rainbow_table/starter/starter.mojo
+++ b/challenges/easy/24_rainbow_table/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn fnv1a_hash(input: Int32) -> UInt32:
+def fnv1a_hash(input: Int32) -> UInt32:
     alias FNV_PRIME: UInt32 = 16777619
     alias OFFSET_BASIS: UInt32 = 2166136261
 
@@ -17,7 +17,7 @@ fn fnv1a_hash(input: Int32) -> UInt32:
     return hash
 
 
-fn fnv1a_hash_kernel(
+def fnv1a_hash_kernel(
     input: UnsafePointer[Int32, MutExternalOrigin],
     output: UnsafePointer[UInt32, MutExternalOrigin],
     N: Int32,
@@ -28,7 +28,7 @@ fn fnv1a_hash_kernel(
 
 # input, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Int32, MutExternalOrigin],
     output: UnsafePointer[UInt32, MutExternalOrigin],
     N: Int32,

--- a/challenges/easy/2_matrix_multiplication/starter/starter.mojo
+++ b/challenges/easy/2_matrix_multiplication/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn matrix_multiplication_kernel(
+def matrix_multiplication_kernel(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     C: UnsafePointer[Float32, MutExternalOrigin],
@@ -17,7 +17,7 @@ fn matrix_multiplication_kernel(
 
 # A, B, C are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     C: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/easy/31_matrix_copy/starter/starter.mojo
+++ b/challenges/easy/31_matrix_copy/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn copy_matrix_kernel(
+def copy_matrix_kernel(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,
@@ -14,7 +14,7 @@ fn copy_matrix_kernel(
 
 # A, B are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/easy/3_matrix_transpose/starter/starter.mojo
+++ b/challenges/easy/3_matrix_transpose/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn matrix_transpose_kernel(
+def matrix_transpose_kernel(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     rows: Int32,
@@ -15,7 +15,7 @@ fn matrix_transpose_kernel(
 
 # input, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     rows: Int32,

--- a/challenges/easy/52_silu/starter/starter.mojo
+++ b/challenges/easy/52_silu/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn silu_kernel(
+def silu_kernel(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,
@@ -14,7 +14,7 @@ fn silu_kernel(
 
 # input, output are device pointers
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/easy/54_swiglu/starter/starter.mojo
+++ b/challenges/easy/54_swiglu/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn swiglu_kernel(
+def swiglu_kernel(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,
@@ -14,7 +14,7 @@ fn swiglu_kernel(
 
 # input, output are device pointers
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/easy/62_value_clipping/starter/starter.mojo
+++ b/challenges/easy/62_value_clipping/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn clip_kernel(
+def clip_kernel(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     lo: Float32,
@@ -16,7 +16,7 @@ fn clip_kernel(
 
 # input, output are device pointers
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     lo: Float32,

--- a/challenges/easy/63_interleave/starter/starter.mojo
+++ b/challenges/easy/63_interleave/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn interleave_kernel(
+def interleave_kernel(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
@@ -15,7 +15,7 @@ fn interleave_kernel(
 
 # A, B, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/easy/65_geglu/starter/starter.mojo
+++ b/challenges/easy/65_geglu/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn geglu_kernel(
+def geglu_kernel(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,
@@ -14,7 +14,7 @@ fn geglu_kernel(
 
 # input, output are device pointers
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/easy/66_rgb_to_grayscale/starter/starter.mojo
+++ b/challenges/easy/66_rgb_to_grayscale/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn rgb_to_grayscale_kernel(
+def rgb_to_grayscale_kernel(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     width: Int32,
@@ -15,7 +15,7 @@ fn rgb_to_grayscale_kernel(
 
 # input, output are device pointers
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     width: Int32,

--- a/challenges/easy/68_sigmoid/starter/starter.mojo
+++ b/challenges/easy/68_sigmoid/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn sigmoid_kernel(
+def sigmoid_kernel(
     X: UnsafePointer[Float32, MutExternalOrigin],
     Y: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,
@@ -14,7 +14,7 @@ fn sigmoid_kernel(
 
 # X, Y are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     X: UnsafePointer[Float32, MutExternalOrigin],
     Y: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/easy/7_color_inversion/starter/starter.mojo
+++ b/challenges/easy/7_color_inversion/starter/starter.mojo
@@ -4,13 +4,13 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn invert_kernel(image: UnsafePointer[UInt8, MutExternalOrigin], width: Int32, height: Int32):
+def invert_kernel(image: UnsafePointer[UInt8, MutExternalOrigin], width: Int32, height: Int32):
     pass
 
 
 # image is a device pointer (i.e. pointer to memory on the GPU)
 @export
-fn solve(image: UnsafePointer[UInt8, MutExternalOrigin], width: Int32, height: Int32) raises:
+def solve(image: UnsafePointer[UInt8, MutExternalOrigin], width: Int32, height: Int32) raises:
     var threadsPerBlock: Int32 = 256
     var ctx = DeviceContext()
 

--- a/challenges/easy/8_matrix_addition/starter/starter.mojo
+++ b/challenges/easy/8_matrix_addition/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn matrix_add_kernel(
+def matrix_add_kernel(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     C: UnsafePointer[Float32, MutExternalOrigin],
@@ -15,7 +15,7 @@ fn matrix_add_kernel(
 
 # A, B, C are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     C: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/easy/9_1d_convolution/starter/starter.mojo
+++ b/challenges/easy/9_1d_convolution/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 from std.math import ceildiv
 
 
-fn convolution_1d_kernel(
+def convolution_1d_kernel(
     input: UnsafePointer[Float32, MutExternalOrigin],
     kernel: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
@@ -16,7 +16,7 @@ fn convolution_1d_kernel(
 
 # input, kernel, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     kernel: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/hard/12_multi_head_attention/starter/starter.mojo
+++ b/challenges/hard/12_multi_head_attention/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     Q: UnsafePointer[Float32, MutExternalOrigin],
     K: UnsafePointer[Float32, MutExternalOrigin],
     V: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/hard/14_multi_agent_sim/starter/starter.mojo
+++ b/challenges/hard/14_multi_agent_sim/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     agents: UnsafePointer[Float32, MutExternalOrigin],
     agents_next: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/hard/15_sorting/starter/starter.mojo
+++ b/challenges/hard/15_sorting/starter/starter.mojo
@@ -5,5 +5,5 @@ from std.math import ceildiv
 
 
 @export
-fn solve(data: UnsafePointer[Float32, MutExternalOrigin], N: Int32) raises:
+def solve(data: UnsafePointer[Float32, MutExternalOrigin], N: Int32) raises:
     pass

--- a/challenges/hard/20_kmeans_clustering/starter/starter.mojo
+++ b/challenges/hard/20_kmeans_clustering/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     data_x: UnsafePointer[Float32, MutExternalOrigin],
     data_y: UnsafePointer[Float32, MutExternalOrigin],
     labels: UnsafePointer[Int32, MutExternalOrigin],

--- a/challenges/hard/36_radix_sort/starter/starter.mojo
+++ b/challenges/hard/36_radix_sort/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.memory import UnsafePointer
 
 # input, output are device pointers
 @export
-fn solve(
+def solve(
     input: UnsafePointer[UInt32, MutExternalOrigin],
     output: UnsafePointer[UInt32, MutExternalOrigin],
     N: Int32,

--- a/challenges/hard/39_Fast_Fourier_transform/starter/starter.mojo
+++ b/challenges/hard/39_Fast_Fourier_transform/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # signal and spectrum are device pointers
 @export
-fn solve(
+def solve(
     signal: UnsafePointer[Float32, MutExternalOrigin],
     spectrum: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/hard/46_bfs_shortest_path/starter/starter.mojo
+++ b/challenges/hard/46_bfs_shortest_path/starter/starter.mojo
@@ -3,7 +3,7 @@ from std.memory import UnsafePointer
 
 # grid, result are device pointers
 @export
-fn solve(
+def solve(
     grid: UnsafePointer[Int32, MutExternalOrigin],
     result: UnsafePointer[Int32, MutExternalOrigin],
     rows: Int32,

--- a/challenges/hard/53_casual_attention/starter/starter.mojo
+++ b/challenges/hard/53_casual_attention/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # Q, K, V, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     Q: UnsafePointer[Float32, MutExternalOrigin],
     K: UnsafePointer[Float32, MutExternalOrigin],
     V: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/hard/56_linear_attention/starter/starter.mojo
+++ b/challenges/hard/56_linear_attention/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # Q, K, V, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     Q: UnsafePointer[Float32, MutExternalOrigin],
     K: UnsafePointer[Float32, MutExternalOrigin],
     V: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/hard/59_sliding_window_attn/starter/starter.mojo
+++ b/challenges/hard/59_sliding_window_attn/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # Q, K, V, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     Q: UnsafePointer[Float32, MutExternalOrigin],
     K: UnsafePointer[Float32, MutExternalOrigin],
     V: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/hard/73_all_pairs_shortest_paths/starter/starter.mojo
+++ b/challenges/hard/73_all_pairs_shortest_paths/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # dist, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     dist: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/hard/74_gpt2_block/starter/starter.mojo
+++ b/challenges/hard/74_gpt2_block/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # x, output, weights are device pointers
 @export
-fn solve(
+def solve(
     x: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     weights: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/10_2d_convolution/starter/starter.mojo
+++ b/challenges/medium/10_2d_convolution/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     kernel: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/11_3d_convolution/starter/starter.mojo
+++ b/challenges/medium/11_3d_convolution/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     kernel: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/13_histogramming/starter/starter.mojo
+++ b/challenges/medium/13_histogramming/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Int32, MutExternalOrigin],
     histogram: UnsafePointer[Int32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/16_prefix_sum/starter/starter.mojo
+++ b/challenges/medium/16_prefix_sum/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/17_dot_product/starter/starter.mojo
+++ b/challenges/medium/17_dot_product/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     result: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/18_sparse_matrix_vector_multiplication/starter/starter.mojo
+++ b/challenges/medium/18_sparse_matrix_vector_multiplication/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float32, MutExternalOrigin],
     x: UnsafePointer[Float32, MutExternalOrigin],
     y: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/22_gemm/starter/starter.mojo
+++ b/challenges/medium/22_gemm/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float16, MutExternalOrigin],
     B: UnsafePointer[Float16, MutExternalOrigin],
     C: UnsafePointer[Float16, MutExternalOrigin],

--- a/challenges/medium/25_categorical_cross_entropy_loss/starter/starter.mojo
+++ b/challenges/medium/25_categorical_cross_entropy_loss/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     logits: UnsafePointer[Float32, MutExternalOrigin],
     true_labels: UnsafePointer[Int32, MutExternalOrigin],
     loss: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/27_mean_squared_error/starter/starter.mojo
+++ b/challenges/medium/27_mean_squared_error/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     predictions: UnsafePointer[Float32, MutExternalOrigin],
     targets: UnsafePointer[Float32, MutExternalOrigin],
     mse: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/28_gaussian_blur/starter/starter.mojo
+++ b/challenges/medium/28_gaussian_blur/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     kernel: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/29_top_k_selection/starter/starter.mojo
+++ b/challenges/medium/29_top_k_selection/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/30_batched_matrix_multiplication/starter/starter.mojo
+++ b/challenges/medium/30_batched_matrix_multiplication/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     C: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/32_int8_quantized_matmul/starter/starter.mojo
+++ b/challenges/medium/32_int8_quantized_matmul/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Int8, MutExternalOrigin],
     B: UnsafePointer[Int8, MutExternalOrigin],
     C: UnsafePointer[Int8, MutExternalOrigin],

--- a/challenges/medium/33_ordinary_least_squares/starter/starter.mojo
+++ b/challenges/medium/33_ordinary_least_squares/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # X, y, beta are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     X: UnsafePointer[Float32, MutExternalOrigin],
     y: UnsafePointer[Float32, MutExternalOrigin],
     beta: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/34_logistic_regression/starter/starter.mojo
+++ b/challenges/medium/34_logistic_regression/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # X, y, beta are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     X: UnsafePointer[Float32, MutExternalOrigin],
     y: UnsafePointer[Float32, MutExternalOrigin],
     beta: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/35_monte_carlo_integration/starter/starter.mojo
+++ b/challenges/medium/35_monte_carlo_integration/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # y_samples, result are device pointers
 @export
-fn solve(
+def solve(
     y_samples: UnsafePointer[Float32, MutExternalOrigin],
     result: UnsafePointer[Float32, MutExternalOrigin],
     a: Float32,

--- a/challenges/medium/37_matrix_power/starter/starter.mojo
+++ b/challenges/medium/37_matrix_power/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # input, output are device pointers
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/38_nearest_neighbor/starter/starter.mojo
+++ b/challenges/medium/38_nearest_neighbor/starter/starter.mojo
@@ -3,7 +3,7 @@ from std.memory import UnsafePointer
 
 # points and indices are device pointers
 @export
-fn solve(
+def solve(
     points: UnsafePointer[Float32, MutExternalOrigin],
     indices: UnsafePointer[Int32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/40_batch_normalization/starter/starter.mojo
+++ b/challenges/medium/40_batch_normalization/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # input, gamma, beta, output are device pointers
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     gamma: UnsafePointer[Float32, MutExternalOrigin],
     beta: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/42_2d_max_pooling/starter/starter.mojo
+++ b/challenges/medium/42_2d_max_pooling/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # input, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/43_count_array_element/starter/starter.mojo
+++ b/challenges/medium/43_count_array_element/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # input, output are device pointers
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Int32, MutExternalOrigin],
     output: UnsafePointer[Int32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/44_count_2d_array_element/starter/starter.mojo
+++ b/challenges/medium/44_count_2d_array_element/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # input, output are device pointers
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Int32, MutExternalOrigin],
     output: UnsafePointer[Int32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/45_count_3d_array_element/starter/starter.mojo
+++ b/challenges/medium/45_count_3d_array_element/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # input, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Int32, MutExternalOrigin],
     output: UnsafePointer[Int32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/47_subarray_sum/starter/starter.mojo
+++ b/challenges/medium/47_subarray_sum/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # input, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Int32, MutExternalOrigin],
     output: UnsafePointer[Int32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/48_2d_subarray_sum/starter/starter.mojo
+++ b/challenges/medium/48_2d_subarray_sum/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # input, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Int32, MutExternalOrigin],
     output: UnsafePointer[Int32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/49_3d_subarray_sum/starter/starter.mojo
+++ b/challenges/medium/49_3d_subarray_sum/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # input, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Int32, MutExternalOrigin],
     output: UnsafePointer[Int32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/4_reduction/starter/starter.mojo
+++ b/challenges/medium/4_reduction/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # input, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/50_rms_normalization/starter/starter.mojo
+++ b/challenges/medium/50_rms_normalization/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # input, output are device pointers
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     gamma: Float32,
     beta: Float32,

--- a/challenges/medium/51_max_subarray_sum/starter/starter.mojo
+++ b/challenges/medium/51_max_subarray_sum/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # input, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Int32, MutExternalOrigin],
     output: UnsafePointer[Int32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/55_attn_w_linear_bias/starter/starter.mojo
+++ b/challenges/medium/55_attn_w_linear_bias/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # Q, K, V, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     Q: UnsafePointer[Float32, MutExternalOrigin],
     K: UnsafePointer[Float32, MutExternalOrigin],
     V: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/57_fp16_batched_matmul/starter/starter.mojo
+++ b/challenges/medium/57_fp16_batched_matmul/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float16, MutExternalOrigin],
     B: UnsafePointer[Float16, MutExternalOrigin],
     C: UnsafePointer[Float16, MutExternalOrigin],

--- a/challenges/medium/58_fp16_dot_product/starter/starter.mojo
+++ b/challenges/medium/58_fp16_dot_product/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # A, B, result are device pointers
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float16, MutExternalOrigin],
     B: UnsafePointer[Float16, MutExternalOrigin],
     result: UnsafePointer[Float16, MutExternalOrigin],

--- a/challenges/medium/5_softmax/starter/starter.mojo
+++ b/challenges/medium/5_softmax/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,

--- a/challenges/medium/60_top_p_sampling/starter/starter.mojo
+++ b/challenges/medium/60_top_p_sampling/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.gpu import block_dim, block_idx, thread_idx
 
 
 @export
-fn solve(
+def solve(
     logits: UnsafePointer[Float32, MutExternalOrigin],
     p: UnsafePointer[Float32, MutExternalOrigin],
     seed: UnsafePointer[Int32, MutExternalOrigin],

--- a/challenges/medium/61_rope_embedding/starter/starter.mojo
+++ b/challenges/medium/61_rope_embedding/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # Q, cos, sin, output are device pointers
 @export
-fn solve(
+def solve(
     Q: UnsafePointer[Float32, MutExternalOrigin],
     cos: UnsafePointer[Float32, MutExternalOrigin],
     sin: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/64_weight_dequantization/starter/starter.mojo
+++ b/challenges/medium/64_weight_dequantization/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # X, S, Y are device pointers
 @export
-fn solve(
+def solve(
     X: UnsafePointer[Float32, MutExternalOrigin],
     S: UnsafePointer[Float32, MutExternalOrigin],
     Y: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/67_moe_topk_gating/starter/starter.mojo
+++ b/challenges/medium/67_moe_topk_gating/starter/starter.mojo
@@ -5,7 +5,7 @@ from std.math import ceildiv
 
 
 @export
-fn solve(
+def solve(
     logits: UnsafePointer[Float32, MutExternalOrigin],
     topk_weights: UnsafePointer[Float32, MutExternalOrigin],
     topk_indices: UnsafePointer[Int32, MutExternalOrigin],

--- a/challenges/medium/69_jacobi_stencil_2d/starter/starter.mojo
+++ b/challenges/medium/69_jacobi_stencil_2d/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # input, output are device pointers
 @export
-fn solve(
+def solve(
     input: UnsafePointer[Float32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],
     rows: Int32,

--- a/challenges/medium/6_softmax_attention/starter/starter.mojo
+++ b/challenges/medium/6_softmax_attention/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # Q, K, V, output are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     Q: UnsafePointer[Float32, MutExternalOrigin],
     K: UnsafePointer[Float32, MutExternalOrigin],
     V: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/70_segmented_prefix_sum/starter/starter.mojo
+++ b/challenges/medium/70_segmented_prefix_sum/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # values, flags, output are device pointers
 @export
-fn solve(
+def solve(
     values: UnsafePointer[Float32, MutExternalOrigin],
     flags: UnsafePointer[Int32, MutExternalOrigin],
     output: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/71_parallel_merge/starter/starter.mojo
+++ b/challenges/medium/71_parallel_merge/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 
 # A, B, C are device pointers (i.e. pointers to memory on the GPU)
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     C: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/72_stream_compaction/starter/starter.mojo
+++ b/challenges/medium/72_stream_compaction/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 
 # A, out are device pointers
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float32, MutExternalOrigin],
     N: Int32,
     out: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/75_sparse_matrix_dense_matrix_multiplication/starter/starter.mojo
+++ b/challenges/medium/75_sparse_matrix_dense_matrix_multiplication/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # A, B, C are device pointers
 @export
-fn solve(
+def solve(
     A: UnsafePointer[Float32, MutExternalOrigin],
     B: UnsafePointer[Float32, MutExternalOrigin],
     C: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/78_2d_fft/starter/starter.mojo
+++ b/challenges/medium/78_2d_fft/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # signal, spectrum are device pointers
 @export
-fn solve(
+def solve(
     signal: UnsafePointer[Float32, MutExternalOrigin],
     spectrum: UnsafePointer[Float32, MutExternalOrigin],
     M: Int32,

--- a/challenges/medium/80_grouped_query_attention/starter/starter.mojo
+++ b/challenges/medium/80_grouped_query_attention/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 
 # Q, K, V, output are device pointers
 @export
-fn solve(
+def solve(
     Q: UnsafePointer[Float32, MutExternalOrigin],
     K: UnsafePointer[Float32, MutExternalOrigin],
     V: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/81_int4_matmul/starter/starter.mojo
+++ b/challenges/medium/81_int4_matmul/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 
 # x, w_q, scales, y are device pointers
 @export
-fn solve(
+def solve(
     x: UnsafePointer[Float16, MutExternalOrigin],
     w_q: UnsafePointer[UInt8, MutExternalOrigin],
     scales: UnsafePointer[Float16, MutExternalOrigin],

--- a/challenges/medium/82_linear_recurrence/starter/starter.mojo
+++ b/challenges/medium/82_linear_recurrence/starter/starter.mojo
@@ -6,7 +6,7 @@ from std.math import ceildiv
 
 # a, x, h are device pointers
 @export
-fn solve(
+def solve(
     a: UnsafePointer[Float32, MutExternalOrigin],
     x: UnsafePointer[Float32, MutExternalOrigin],
     h: UnsafePointer[Float32, MutExternalOrigin],

--- a/challenges/medium/85_lora_linear/starter/starter.mojo
+++ b/challenges/medium/85_lora_linear/starter/starter.mojo
@@ -4,7 +4,7 @@ from std.memory import UnsafePointer
 
 # x, W, A, B, output are device pointers
 @export
-fn solve(
+def solve(
     x: UnsafePointer[Float32, MutExternalOrigin],
     W: UnsafePointer[Float32, MutExternalOrigin],
     A: UnsafePointer[Float32, MutExternalOrigin],


### PR DESCRIPTION
## Summary
Mojo 26.2 deprecates the \`fn\` keyword per the RFC **\"Remove fn from Mojo, def no longer implies raises\"** (accepted 23 Feb 2026). Going forward:

- \`def foo(...)\` — non-raising (was \`fn\`)
- \`def foo(...) raises\` — raising form (was \`fn ... raises\`, replaces the old implicitly-raising \`def\`)

\`fn\` will be removed before 1.0. Every starter currently emits a deprecation warning on compile. This sweeps all 79 \`starter.mojo\` files to the new form now so learners don't see the dead keyword.

## Mapping

| before | after |
| --- | --- |
| \`fn vector_add_kernel(...)\` | \`def vector_add_kernel(...)\` |
| \`@export fn solve(...) raises:\` | \`@export def solve(...) raises:\` |

Kernels drop to plain \`def\` — they don't raise. \`solve\` keeps the \`raises\` because it calls \`DeviceContext\`, \`compile_function\`, \`enqueue_function\`, and \`synchronize\`, all of which raise.

## Test plan
- [x] Transformed \`vector_add\` starter compiles cleanly on Mojo 26.2 via the prod compiler container (\`mojo build --emit=shared-lib --target-accelerator=sm_75\` → exit 0, exported \`solve\` symbol in the \`.so\`).
- [ ] CI lint / pre-commit passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)