### PR TITLE
Use short GPU names in scripts

### DIFF
--- a/scripts/run_challenge.py
+++ b/scripts/run_challenge.py
@@ -95,9 +95,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Submit a solution via WebSocket API.")
     parser.add_argument("challenge_path", type=Path, help="Path to the challenge directory")
     parser.add_argument("--language", default="cuda", help="Language (default: cuda)")
-    parser.add_argument(
-        "--gpu", default="NVIDIA TESLA T4", help="GPU name (default: NVIDIA TESLA T4)"
-    )
+    parser.add_argument("--gpu", default="T4", help="GPU name (default: T4)")
     parser.add_argument(
         "--action", default="run", choices=["run", "submit"], help="Action (run or submit)"
     )

--- a/scripts/update_challenges.py
+++ b/scripts/update_challenges.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 SERVICE_URL = os.getenv("SERVICE_URL", "http://localhost:8080")
 LEETGPU_API_KEY = os.getenv("LEETGPU_API_KEY")
 
-GPUS = ["NVIDIA H100", "NVIDIA H200", "NVIDIA TESLA T4", "NVIDIA B200", "NVIDIA A100-80GB"]
+GPUS = ["H100", "H200", "T4", "B200", "A100-80GB"]
 
 
 def extract_id(name: str) -> int:


### PR DESCRIPTION
## Summary
- Server-side GPU identifiers are moving from `NVIDIA TESLA T4`, `NVIDIA H100`, … to short forms (`T4`, `H100`, …). See AlphaGPU/leetgpu-infra#343.
- Update `scripts/run_challenge.py` (`--gpu` default) and `scripts/update_challenges.py` (`GPUS` list) to send the new names.

## Test plan
- [ ] Merge after AlphaGPU/leetgpu-infra#343 lands and the migration is applied
- [ ] `python scripts/run_challenge.py challenges/easy/1_vector_add` (defaults to T4) succeeds end-to-end
- [ ] `python scripts/update_challenges.py` syncs challenge GPUs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)