### PR TITLE
Add challenge 100: Softmax Attention Backward (Medium)

### DIFF
--- a/challenges/medium/100_softmax_attention_backward/challenge.html
+++ b/challenges/medium/100_softmax_attention_backward/challenge.html
@@ -1,0 +1,86 @@
+<p>
+  Given the query matrix <code>Q</code> of size <code>M&times;d</code>, key matrix <code>K</code> of size
+  <code>N&times;d</code>, value matrix <code>V</code> of size <code>N&times;d</code>, and upstream gradient
+  <code>dO</code> of size <code>M&times;d</code>, compute the gradients of the softmax attention operation
+  with respect to <code>Q</code>, <code>K</code>, and <code>V</code>. The forward pass computes
+  $$O = \text{softmax}\!\Bigl(\frac{QK^T}{\sqrt{d}}\Bigr)V,$$
+  where softmax is applied row-wise. The backward pass produces <code>dQ</code> (M&times;d),
+  <code>dK</code> (N&times;d), and <code>dV</code> (N&times;d) via:
+  $$P = \text{softmax}\!\Bigl(\frac{QK^T}{\sqrt{d}}\Bigr), \quad dV = P^T\,dO,$$
+  $$dP = dO\,V^T, \quad dS_{ij} = P_{ij}\!\left(dP_{ij} - \sum_k P_{ik}\,dP_{ik}\right), \quad \widetilde{dS} = \frac{dS}{\sqrt{d}},$$
+  $$dQ = \widetilde{dS}\,K, \quad dK = \widetilde{dS}^T Q.$$
+</p>
+<h2>Implementation Requirements</h2>
+<ul>
+  <li>Use only GPU native features (external libraries are not permitted)</li>
+  <li>The <code>solve</code> function signature must remain unchanged</li>
+  <li>The final results must be stored in <code>dQ</code>, <code>dK</code>, and <code>dV</code></li>
+</ul>
+<h2>Example</h2>
+<p>
+<strong>Input:</strong><br>
+<code>Q</code> (2&times;4):
+\[
+\begin{bmatrix}
+1.0 & 0.0 & 0.0 & 0.0 \\
+0.0 & 1.0 & 0.0 & 0.0
+\end{bmatrix}
+\]
+<code>K</code> (3&times;4):
+\[
+\begin{bmatrix}
+1.0 & 0.0 & 0.0 & 0.0 \\
+0.0 & 1.0 & 0.0 & 0.0 \\
+0.0 & 0.0 & 1.0 & 0.0
+\end{bmatrix}
+\]
+<code>V</code> (3&times;4):
+\[
+\begin{bmatrix}
+1.0 & 2.0 & 3.0 & 4.0 \\
+5.0 & 6.0 & 7.0 & 8.0 \\
+9.0 & 10.0 & 11.0 & 12.0
+\end{bmatrix}
+\]
+<code>dO</code> (2&times;4):
+\[
+\begin{bmatrix}
+1.0 & 0.0 & 0.0 & 0.0 \\
+0.0 & 1.0 & 0.0 & 0.0
+\end{bmatrix}
+\]
+</p>
+<p>
+<strong>Output:</strong><br>
+<code>dQ</code> (2&times;4):
+\[
+\begin{bmatrix}
+-0.74 & 0.10 & 0.65 & 0.00 \\
+-0.55 & 0.00 & 0.55 & 0.00
+\end{bmatrix}
+\]
+<code>dK</code> (3&times;4):
+\[
+\begin{bmatrix}
+-0.74 & -0.55 & 0.00 & 0.00 \\
+0.10 & 0.00 & 0.00 & 0.00 \\
+0.65 & 0.55 & 0.00 & 0.00
+\end{bmatrix}
+\]
+<code>dV</code> (3&times;4):
+\[
+\begin{bmatrix}
+0.45 & 0.27 & 0.00 & 0.00 \\
+0.27 & 0.45 & 0.00 & 0.00 \\
+0.27 & 0.27 & 0.00 & 0.00
+\end{bmatrix}
+\]
+</p>
+<h2>Constraints</h2>
+<ul>
+  <li>Matrix <code>Q</code> and <code>dO</code> are of size <code>M&times;d</code>; matrices <code>K</code>, <code>V</code> are of size <code>N&times;d</code></li>
+  <li>1 &le; <code>M</code>, <code>N</code> &le; 100,000</li>
+  <li>1 &le; <code>d</code> &le; 128</li>
+  <li>All input values are <code>float32</code></li>
+  <li>Performance is measured with <code>M</code> = 512, <code>N</code> = 256, <code>d</code> = 128</li>
+</ul>

--- a/challenges/medium/100_softmax_attention_backward/challenge.py
+++ b/challenges/medium/100_softmax_attention_backward/challenge.py
@@ -1,0 +1,273 @@
+import ctypes
+from typing import Any, Dict, List
+
+import torch
+from core.challenge_base import ChallengeBase
+
+
+class Challenge(ChallengeBase):
+    def __init__(self):
+        super().__init__(
+            name="Softmax Attention Backward",
+            atol=1e-04,
+            rtol=1e-04,
+            num_gpus=1,
+            access_tier="free",
+        )
+
+    def reference_impl(
+        self,
+        Q: torch.Tensor,
+        K: torch.Tensor,
+        V: torch.Tensor,
+        dO: torch.Tensor,
+        dQ: torch.Tensor,
+        dK: torch.Tensor,
+        dV: torch.Tensor,
+        M: int,
+        N: int,
+        d: int,
+    ):
+        assert Q.shape == (M, d)
+        assert K.shape == (N, d)
+        assert V.shape == (N, d)
+        assert dO.shape == (M, d)
+        assert dQ.shape == (M, d)
+        assert dK.shape == (N, d)
+        assert dV.shape == (N, d)
+        assert Q.dtype == torch.float32
+        assert Q.is_cuda and K.is_cuda and V.is_cuda and dO.is_cuda
+        assert dQ.is_cuda and dK.is_cuda and dV.is_cuda
+
+        scale = d**0.5
+        S = torch.matmul(Q, K.t()) / scale
+        P = torch.softmax(S, dim=1)
+        torch.matmul(P.t(), dO, out=dV)
+        dP = torch.matmul(dO, V.t())
+        dS = dP * P - P * (dP * P).sum(dim=1, keepdim=True)
+        dS = dS / scale
+        torch.matmul(dS, K, out=dQ)
+        torch.matmul(dS.t(), Q, out=dK)
+
+    def get_solve_signature(self) -> Dict[str, tuple]:
+        return {
+            "Q": (ctypes.POINTER(ctypes.c_float), "in"),
+            "K": (ctypes.POINTER(ctypes.c_float), "in"),
+            "V": (ctypes.POINTER(ctypes.c_float), "in"),
+            "dO": (ctypes.POINTER(ctypes.c_float), "in"),
+            "dQ": (ctypes.POINTER(ctypes.c_float), "out"),
+            "dK": (ctypes.POINTER(ctypes.c_float), "out"),
+            "dV": (ctypes.POINTER(ctypes.c_float), "out"),
+            "M": (ctypes.c_int, "in"),
+            "N": (ctypes.c_int, "in"),
+            "d": (ctypes.c_int, "in"),
+        }
+
+    def generate_example_test(self) -> Dict[str, Any]:
+        dtype = torch.float32
+        Q = torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype)
+        K = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
+            device="cuda",
+            dtype=dtype,
+        )
+        V = torch.tensor(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
+            device="cuda",
+            dtype=dtype,
+        )
+        dO = torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype)
+        return {
+            "Q": Q,
+            "K": K,
+            "V": V,
+            "dO": dO,
+            "dQ": torch.empty(2, 4, device="cuda", dtype=dtype),
+            "dK": torch.empty(3, 4, device="cuda", dtype=dtype),
+            "dV": torch.empty(3, 4, device="cuda", dtype=dtype),
+            "M": 2,
+            "N": 3,
+            "d": 4,
+        }
+
+    def generate_functional_test(self) -> List[Dict[str, Any]]:
+        dtype = torch.float32
+        tests = []
+
+        # minimal_edge_case
+        tests.append(
+            {
+                "Q": torch.tensor([[1.0]], device="cuda", dtype=dtype),
+                "K": torch.tensor([[1.0]], device="cuda", dtype=dtype),
+                "V": torch.tensor([[2.0]], device="cuda", dtype=dtype),
+                "dO": torch.tensor([[1.0]], device="cuda", dtype=dtype),
+                "dQ": torch.empty(1, 1, device="cuda", dtype=dtype),
+                "dK": torch.empty(1, 1, device="cuda", dtype=dtype),
+                "dV": torch.empty(1, 1, device="cuda", dtype=dtype),
+                "M": 1,
+                "N": 1,
+                "d": 1,
+            }
+        )
+
+        # basic_example
+        tests.append(
+            {
+                "Q": torch.tensor(
+                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype
+                ),
+                "K": torch.tensor(
+                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
+                    device="cuda",
+                    dtype=dtype,
+                ),
+                "V": torch.tensor(
+                    [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
+                    device="cuda",
+                    dtype=dtype,
+                ),
+                "dO": torch.tensor(
+                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype
+                ),
+                "dQ": torch.empty(2, 4, device="cuda", dtype=dtype),
+                "dK": torch.empty(3, 4, device="cuda", dtype=dtype),
+                "dV": torch.empty(3, 4, device="cuda", dtype=dtype),
+                "M": 2,
+                "N": 3,
+                "d": 4,
+            }
+        )
+
+        # zero_inputs
+        tests.append(
+            {
+                "Q": torch.zeros((3, 5), device="cuda", dtype=dtype),
+                "K": torch.zeros((4, 5), device="cuda", dtype=dtype),
+                "V": torch.zeros((4, 5), device="cuda", dtype=dtype),
+                "dO": torch.zeros((3, 5), device="cuda", dtype=dtype),
+                "dQ": torch.empty(3, 5, device="cuda", dtype=dtype),
+                "dK": torch.empty(4, 5, device="cuda", dtype=dtype),
+                "dV": torch.empty(4, 5, device="cuda", dtype=dtype),
+                "M": 3,
+                "N": 4,
+                "d": 5,
+            }
+        )
+
+        # negative_and_mixed_values
+        tests.append(
+            {
+                "Q": torch.tensor(
+                    [[-1.0, 2.0, -3.0], [4.0, -5.0, 6.0], [-7.0, 8.0, -9.0], [10.0, -11.0, 12.0]],
+                    device="cuda",
+                    dtype=dtype,
+                ),
+                "K": torch.tensor(
+                    [[2.0, -1.0, 3.0], [-4.0, 5.0, -6.0], [7.0, -8.0, 9.0], [-10.0, 11.0, -12.0]],
+                    device="cuda",
+                    dtype=dtype,
+                ),
+                "V": torch.tensor(
+                    [[1.0, 0.5, -0.5], [-1.0, 2.0, 3.0], [4.0, -2.0, 1.0], [0.0, 1.0, -1.0]],
+                    device="cuda",
+                    dtype=dtype,
+                ),
+                "dO": torch.tensor(
+                    [[-0.5, 1.0, 0.5], [0.5, -1.0, 0.5], [1.0, 0.5, -0.5], [-0.5, 0.5, 1.0]],
+                    device="cuda",
+                    dtype=dtype,
+                ),
+                "dQ": torch.empty(4, 3, device="cuda", dtype=dtype),
+                "dK": torch.empty(4, 3, device="cuda", dtype=dtype),
+                "dV": torch.empty(4, 3, device="cuda", dtype=dtype),
+                "M": 4,
+                "N": 4,
+                "d": 3,
+            }
+        )
+
+        # power_of_2_small
+        tests.append(
+            {
+                "Q": torch.empty((16, 8), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "K": torch.empty((16, 8), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "V": torch.empty((16, 8), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "dO": torch.empty((16, 8), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "dQ": torch.empty(16, 8, device="cuda", dtype=dtype),
+                "dK": torch.empty(16, 8, device="cuda", dtype=dtype),
+                "dV": torch.empty(16, 8, device="cuda", dtype=dtype),
+                "M": 16,
+                "N": 16,
+                "d": 8,
+            }
+        )
+
+        # power_of_2_medium
+        tests.append(
+            {
+                "Q": torch.empty((64, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "K": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "V": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "dO": torch.empty((64, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "dQ": torch.empty(64, 32, device="cuda", dtype=dtype),
+                "dK": torch.empty(128, 32, device="cuda", dtype=dtype),
+                "dV": torch.empty(128, 32, device="cuda", dtype=dtype),
+                "M": 64,
+                "N": 128,
+                "d": 32,
+            }
+        )
+
+        # non_power_of_2_small
+        tests.append(
+            {
+                "Q": torch.empty((30, 7), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "K": torch.empty((15, 7), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "V": torch.empty((15, 7), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "dO": torch.empty((30, 7), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "dQ": torch.empty(30, 7, device="cuda", dtype=dtype),
+                "dK": torch.empty(15, 7, device="cuda", dtype=dtype),
+                "dV": torch.empty(15, 7, device="cuda", dtype=dtype),
+                "M": 30,
+                "N": 15,
+                "d": 7,
+            }
+        )
+
+        # non_power_of_2_large
+        tests.append(
+            {
+                "Q": torch.empty((100, 50), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "K": torch.empty((255, 50), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "V": torch.empty((255, 50), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "dO": torch.empty((100, 50), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
+                "dQ": torch.empty(100, 50, device="cuda", dtype=dtype),
+                "dK": torch.empty(255, 50, device="cuda", dtype=dtype),
+                "dV": torch.empty(255, 50, device="cuda", dtype=dtype),
+                "M": 100,
+                "N": 255,
+                "d": 50,
+            }
+        )
+
+        return tests
+
+    def generate_performance_test(self) -> Dict[str, Any]:
+        dtype = torch.float32
+        M, N, d = 512, 256, 128
+        Q = torch.empty((M, d), device="cuda", dtype=dtype).uniform_(-0.1, 0.1)
+        K = torch.empty((N, d), device="cuda", dtype=dtype).uniform_(-0.1, 0.1)
+        V = torch.empty((N, d), device="cuda", dtype=dtype).uniform_(-0.1, 0.1)
+        dO = torch.empty((M, d), device="cuda", dtype=dtype).uniform_(-0.1, 0.1)
+        return {
+            "Q": Q,
+            "K": K,
+            "V": V,
+            "dO": dO,
+            "dQ": torch.empty(M, d, device="cuda", dtype=dtype),
+            "dK": torch.empty(N, d, device="cuda", dtype=dtype),
+            "dV": torch.empty(N, d, device="cuda", dtype=dtype),
+            "M": M,
+            "N": N,
+            "d": d,
+        }

--- a/challenges/medium/100_softmax_attention_backward/starter/starter.cu
+++ b/challenges/medium/100_softmax_attention_backward/starter/starter.cu
@@ -1,0 +1,5 @@
+#include <cuda_runtime.h>
+
+// Q, K, V, dO, dQ, dK, dV are device pointers
+extern "C" void solve(const float* Q, const float* K, const float* V, const float* dO, float* dQ,
+                      float* dK, float* dV, int M, int N, int d) {}

--- a/challenges/medium/100_softmax_attention_backward/starter/starter.cute.py
+++ b/challenges/medium/100_softmax_attention_backward/starter/starter.cute.py
@@ -1,0 +1,19 @@
+import cutlass
+import cutlass.cute as cute
+
+
+# Q, K, V, dO, dQ, dK, dV are tensors on the GPU
+@cute.jit
+def solve(
+    Q: cute.Tensor,
+    K: cute.Tensor,
+    V: cute.Tensor,
+    dO: cute.Tensor,
+    dQ: cute.Tensor,
+    dK: cute.Tensor,
+    dV: cute.Tensor,
+    M: cute.Int32,
+    N: cute.Int32,
+    d: cute.Int32,
+):
+    pass

--- a/challenges/medium/100_softmax_attention_backward/starter/starter.jax.py
+++ b/challenges/medium/100_softmax_attention_backward/starter/starter.jax.py
@@ -1,0 +1,11 @@
+import jax
+import jax.numpy as jnp
+
+
+# Q, K, V, dO are tensors on GPU
+@jax.jit
+def solve(
+    Q: jax.Array, K: jax.Array, V: jax.Array, dO: jax.Array, M: int, N: int, d: int
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    # return output tensor directly
+    pass

--- a/challenges/medium/100_softmax_attention_backward/starter/starter.mojo
+++ b/challenges/medium/100_softmax_attention_backward/starter/starter.mojo
@@ -1,21 +1,19 @@
-from std.gpu.host import DeviceContext
-from std.gpu import block_dim, block_idx, thread_idx
-from std.memory import UnsafePointer
-from std.math import ceildiv
+from gpu.host import DeviceContext
+from memory import UnsafePointer
 
 
 # Q, K, V, dO, dQ, dK, dV are device pointers
 @export
 def solve(
-    Q: UnsafePointer[Float32, MutExternalOrigin],
-    K: UnsafePointer[Float32, MutExternalOrigin],
-    V: UnsafePointer[Float32, MutExternalOrigin],
-    dO: UnsafePointer[Float32, MutExternalOrigin],
-    dQ: UnsafePointer[Float32, MutExternalOrigin],
-    dK: UnsafePointer[Float32, MutExternalOrigin],
-    dV: UnsafePointer[Float32, MutExternalOrigin],
+    Q: UnsafePointer[Float32],
+    K: UnsafePointer[Float32],
+    V: UnsafePointer[Float32],
+    dO: UnsafePointer[Float32],
+    dQ: UnsafePointer[Float32],
+    dK: UnsafePointer[Float32],
+    dV: UnsafePointer[Float32],
     M: Int32,
     N: Int32,
     d: Int32,
-) raises:
+):
     pass

--- a/challenges/medium/100_softmax_attention_backward/starter/starter.mojo
+++ b/challenges/medium/100_softmax_attention_backward/starter/starter.mojo
@@ -1,0 +1,21 @@
+from std.gpu.host import DeviceContext
+from std.gpu import block_dim, block_idx, thread_idx
+from std.memory import UnsafePointer
+from std.math import ceildiv
+
+
+# Q, K, V, dO, dQ, dK, dV are device pointers
+@export
+def solve(
+    Q: UnsafePointer[Float32, MutExternalOrigin],
+    K: UnsafePointer[Float32, MutExternalOrigin],
+    V: UnsafePointer[Float32, MutExternalOrigin],
+    dO: UnsafePointer[Float32, MutExternalOrigin],
+    dQ: UnsafePointer[Float32, MutExternalOrigin],
+    dK: UnsafePointer[Float32, MutExternalOrigin],
+    dV: UnsafePointer[Float32, MutExternalOrigin],
+    M: Int32,
+    N: Int32,
+    d: Int32,
+) raises:
+    pass

--- a/challenges/medium/100_softmax_attention_backward/starter/starter.pytorch.py
+++ b/challenges/medium/100_softmax_attention_backward/starter/starter.pytorch.py
@@ -1,0 +1,17 @@
+import torch
+
+
+# Q, K, V, dO, dQ, dK, dV are tensors on the GPU
+def solve(
+    Q: torch.Tensor,
+    K: torch.Tensor,
+    V: torch.Tensor,
+    dO: torch.Tensor,
+    dQ: torch.Tensor,
+    dK: torch.Tensor,
+    dV: torch.Tensor,
+    M: int,
+    N: int,
+    d: int,
+):
+    pass

--- a/challenges/medium/100_softmax_attention_backward/starter/starter.triton.py
+++ b/challenges/medium/100_softmax_attention_backward/starter/starter.triton.py
@@ -1,0 +1,19 @@
+import torch
+import triton
+import triton.language as tl
+
+
+# Q, K, V, dO, dQ, dK, dV are tensors on the GPU
+def solve(
+    Q: torch.Tensor,
+    K: torch.Tensor,
+    V: torch.Tensor,
+    dO: torch.Tensor,
+    dQ: torch.Tensor,
+    dK: torch.Tensor,
+    dV: torch.Tensor,
+    M: int,
+    N: int,
+    d: int,
+):
+    pass


### PR DESCRIPTION
#Summary
- Adds challenge 100: Softmax Attention Backward, the backward pass through scaled dot-product attention.
- Given Q (M×d), K (N×d), V (N×d), and upstream gradient dO (M×d), the solver must compute dQ, dK, and dV by propagating gradients through the softmax Jacobian-vector product and the scaling factor 1/√d. This is a natural follow-up to challenge 6 (Softmax Attention).
- Includes challenge.py (8 functional tests covering edge cases, zeros, negatives, powers-of-2, non-powers-of-2, and a performance test of M=512 × N=256 × d=128), challenge.html with full backward pass derivation, and starter files for all six frameworks.