### PR TITLE
Clarify matrix copy CUDA starter kernel size

### DIFF
--- a/challenges/easy/31_matrix_copy/starter/starter.cu
+++ b/challenges/easy/31_matrix_copy/starter/starter.cu
@@ -1,12 +1,12 @@
 #include <cuda_runtime.h>
 
-__global__ void copy_matrix_kernel(const float* A, float* B, int N) {}
+__global__ void copy_matrix_kernel(const float* A, float* B, int total) {}
 
 // A, B are device pointers (i.e. pointers to memory on the GPU)
 extern "C" void solve(const float* A, float* B, int N) {
     int total = N * N;
     int threadsPerBlock = 256;
     int blocksPerGrid = (total + threadsPerBlock - 1) / threadsPerBlock;
-    copy_matrix_kernel<<<blocksPerGrid, threadsPerBlock>>>(A, B, N);
+    copy_matrix_kernel<<<blocksPerGrid, threadsPerBlock>>>(A, B, total);
     cudaDeviceSynchronize();
 }

--- a/challenges/medium/87_speculative_decoding_verification/starter/starter.mojo
+++ b/challenges/medium/87_speculative_decoding_verification/starter/starter.mojo
@@ -1,6 +1,7 @@
 from gpu.host import DeviceContext
 from memory import UnsafePointer
 
+
 # draft_tokens, draft_probs, target_probs, uniform_samples, output_tokens are device pointers
 @export
 def solve(

--- a/challenges/medium/90_causal_depthwise_conv1d/starter/starter.mojo
+++ b/challenges/medium/90_causal_depthwise_conv1d/starter/starter.mojo
@@ -1,6 +1,7 @@
 from gpu.host import DeviceContext
 from memory import UnsafePointer
 
+
 # x, weight, bias, output are device pointers
 @export
 def solve(


### PR DESCRIPTION
  ## Summary
  - Pass total element count to the Matrix Copy CUDA starter
kernel instead of N
  - Keep solve signature unchanged and compute N * N on the
host side

  ## Notes
  - This keeps the starter aligned with a linear element-wise
copy model