### PR TITLE
Add device kwarg to Challenge for TPU/XLA support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,21 +38,23 @@ Must inherit from `ChallengeBase` and follow Black formatting (line length 100).
 
 ### Required Methods
 
-#### `__init__`
+#### Class attributes (no `__init__`)
 ```python
-super().__init__(
-    name="Challenge Display Name",  # Used to generate URLs — use URL-friendly characters only (no parentheses, special symbols, etc.)
-    atol=1e-05,           # Absolute tolerance (float32 default)
-    rtol=1e-05,           # Relative tolerance (float32 default)
-    num_gpus=1,
-    access_tier="free"    # "free" or "premium"
-)
+class Challenge(ChallengeBase):
+    name = "Challenge Display Name"  # Used to generate URLs — URL-friendly characters only (no parentheses or special symbols)
+    atol = 1e-05           # Absolute tolerance (float32 default)
+    rtol = 1e-05           # Relative tolerance (float32 default)
+    num_gpus = 1
+    access_tier = "free"   # "free" or "premium"
 ```
+
+No `__init__` — `ChallengeBase` provides one that accepts `device` (default `"cuda"`). All tensor allocations in `generate_*_test` methods must use `device=self.device`, never hardcoded `device="cuda"`.
 
 #### `reference_impl(self, ...)`
 - Same parameters as user's `solve` function
-- Must include assertions on shape, dtype, and device (`cuda`)
+- Must include assertions on shape and dtype (no device assertions — the runner targets multiple accelerators)
 - Use PyTorch operations (not Python loops) for performance
+- **Must work on both CUDA and XLA (TPU) devices.** Stick to standard PyTorch ops that have XLA lowerings. No CUDA-only kernels (`flash_attn`, `sdp_kernel`, manual cuDNN flag flips), no `.is_cuda` / `.device.type == "cuda"` checks, no `torch.cuda.*` API.
 
 #### `get_solve_signature(self) -> Dict[str, tuple]`
 Maps parameter names to `(ctype, direction)` tuples.
@@ -186,9 +188,11 @@ Verify every item before submitting. This is the single source of truth — work
 
 ### challenge.py
 - [ ] `class Challenge` inherits `ChallengeBase`
-- [ ] `__init__` calls `super().__init__()` with name, atol, rtol, num_gpus, access_tier
-- [ ] `reference_impl` has assertions on shape, dtype, and device
-- [ ] All 6 methods present: `__init__`, `reference_impl`, `get_solve_signature`, `generate_example_test`, `generate_functional_test`, `generate_performance_test`
+- [ ] Five class attributes set: `name`, `atol`, `rtol`, `num_gpus`, `access_tier` (no `__init__`)
+- [ ] `reference_impl` has assertions on shape and dtype only (no device-specific checks)
+- [ ] `reference_impl` works on both CUDA and XLA — standard PyTorch ops only, no CUDA-only kernels or `torch.cuda.*` API
+- [ ] All tensor allocations use `device=self.device`, never hardcoded `"cuda"`
+- [ ] All 5 required methods present: `reference_impl`, `get_solve_signature`, `generate_example_test`, `generate_functional_test`, `generate_performance_test`
 - [ ] `generate_functional_test` returns 7-10 cases: edge cases (1-4 elements), powers-of-2, non-powers-of-2, realistic sizes, zeros, negatives
 - [ ] `generate_performance_test` fits 5x in 16GB VRAM (Tesla T4)
 

--- a/challenges/core/challenge_base.py
+++ b/challenges/core/challenge_base.py
@@ -3,12 +3,14 @@ from typing import Any, Dict, List
 
 
 class ChallengeBase(ABC):
-    def __init__(self, name: str, atol: float, rtol: float, num_gpus: int, access_tier: str):
-        self.name = name
-        self.atol = atol
-        self.rtol = rtol
-        self.num_gpus = num_gpus
-        self.access_tier = access_tier
+    name: str
+    atol: float
+    rtol: float
+    num_gpus: int
+    access_tier: str
+
+    def __init__(self, device: str = "cuda"):
+        self.device = device
 
     @abstractmethod
     def reference_impl(self, *args, **kwargs):

--- a/challenges/easy/19_reverse_array/challenge.py
+++ b/challenges/easy/19_reverse_array/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Reverse Array", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Reverse Array"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, N: int):
         assert input.shape == (N,)
@@ -26,7 +27,7 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        input_tensor = torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype)
+        input_tensor = torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype)
         return {
             "input": input_tensor,
             "N": 4,
@@ -39,12 +40,14 @@ class Challenge(ChallengeBase):
 
         # Fixed value test cases
         test_cases.append(
-            {"input": torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype), "N": 4}
+            {"input": torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype), "N": 4}
         )
 
-        test_cases.append({"input": torch.tensor([42.0], device="cuda", dtype=dtype), "N": 1})
+        test_cases.append({"input": torch.tensor([42.0], device=self.device, dtype=dtype), "N": 1})
 
-        test_cases.append({"input": torch.tensor([0.0] * 16, device="cuda", dtype=dtype), "N": 16})
+        test_cases.append(
+            {"input": torch.tensor([0.0] * 16, device=self.device, dtype=dtype), "N": 16}
+        )
 
         test_cases.append(
             {
@@ -81,7 +84,7 @@ class Challenge(ChallengeBase):
                         28.0,
                         29.0,
                     ],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "N": 30,
@@ -89,17 +92,20 @@ class Challenge(ChallengeBase):
         )
 
         test_cases.append(
-            {"input": torch.tensor([-1.0, -2.0, -3.0, -4.0], device="cuda", dtype=dtype), "N": 4}
+            {
+                "input": torch.tensor([-1.0, -2.0, -3.0, -4.0], device=self.device, dtype=dtype),
+                "N": 4,
+            }
         )
 
         test_cases.append(
-            {"input": torch.tensor([1.0, -2.0, 3.0, -4.0], device="cuda", dtype=dtype), "N": 4}
+            {"input": torch.tensor([1.0, -2.0, 3.0, -4.0], device=self.device, dtype=dtype), "N": 4}
         )
 
         test_cases.append(
             {
                 "input": torch.tensor(
-                    [0.000001, 0.0000001, 0.00000001, 0.000000001], device="cuda", dtype=dtype
+                    [0.000001, 0.0000001, 0.00000001, 0.000000001], device=self.device, dtype=dtype
                 ),
                 "N": 4,
             }
@@ -108,7 +114,9 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "input": torch.tensor(
-                    [1000000.0, 10000000.0, -1000000.0, -10000000.0], device="cuda", dtype=dtype
+                    [1000000.0, 10000000.0, -1000000.0, -10000000.0],
+                    device=self.device,
+                    dtype=dtype,
                 ),
                 "N": 4,
             }
@@ -116,15 +124,21 @@ class Challenge(ChallengeBase):
 
         # Random range test cases
         test_cases.append(
-            {"input": torch.empty(32, device="cuda", dtype=dtype).uniform_(0.0, 32.0), "N": 32}
+            {"input": torch.empty(32, device=self.device, dtype=dtype).uniform_(0.0, 32.0), "N": 32}
         )
 
         test_cases.append(
-            {"input": torch.empty(1000, device="cuda", dtype=dtype).uniform_(0.0, 7.0), "N": 1000}
+            {
+                "input": torch.empty(1000, device=self.device, dtype=dtype).uniform_(0.0, 7.0),
+                "N": 1000,
+            }
         )
 
         test_cases.append(
-            {"input": torch.empty(10000, device="cuda", dtype=dtype).uniform_(0.0, 1.0), "N": 10000}
+            {
+                "input": torch.empty(10000, device=self.device, dtype=dtype).uniform_(0.0, 1.0),
+                "N": 10000,
+            }
         )
 
         return test_cases
@@ -133,6 +147,6 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 25000000
         return {
-            "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0),
+            "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-1000.0, 1000.0),
             "N": N,
         }

--- a/challenges/easy/1_vector_add/challenge.py
+++ b/challenges/easy/1_vector_add/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Vector Addition", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Vector Addition"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, A: torch.Tensor, B: torch.Tensor, C: torch.Tensor, N: int):
         assert A.shape == B.shape == C.shape
@@ -29,9 +30,9 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 4
-        A = torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype)
-        B = torch.tensor([5.0, 6.0, 7.0, 8.0], device="cuda", dtype=dtype)
-        C = torch.empty(N, device="cuda", dtype=dtype)
+        A = torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype)
+        B = torch.tensor([5.0, 6.0, 7.0, 8.0], device=self.device, dtype=dtype)
+        C = torch.empty(N, device=self.device, dtype=dtype)
         return {
             "A": A,
             "B": B,
@@ -67,9 +68,9 @@ class Challenge(ChallengeBase):
             n = len(a_vals)
             test_cases.append(
                 {
-                    "A": torch.tensor(a_vals, device="cuda", dtype=dtype),
-                    "B": torch.tensor(b_vals, device="cuda", dtype=dtype),
-                    "C": torch.zeros(n, device="cuda", dtype=dtype),
+                    "A": torch.tensor(a_vals, device=self.device, dtype=dtype),
+                    "B": torch.tensor(b_vals, device=self.device, dtype=dtype),
+                    "C": torch.zeros(n, device=self.device, dtype=dtype),
                     "N": n,
                 }
             )
@@ -82,9 +83,9 @@ class Challenge(ChallengeBase):
         ]:
             test_cases.append(
                 {
-                    "A": torch.empty(size, device="cuda", dtype=dtype).uniform_(*a_range),
-                    "B": torch.empty(size, device="cuda", dtype=dtype).uniform_(*b_range),
-                    "C": torch.zeros(size, device="cuda", dtype=dtype),
+                    "A": torch.empty(size, device=self.device, dtype=dtype).uniform_(*a_range),
+                    "B": torch.empty(size, device=self.device, dtype=dtype).uniform_(*b_range),
+                    "C": torch.zeros(size, device=self.device, dtype=dtype),
                     "N": size,
                 }
             )
@@ -95,8 +96,8 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 25000000
         return {
-            "A": torch.empty(N, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0),
-            "B": torch.empty(N, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0),
-            "C": torch.zeros(N, device="cuda", dtype=dtype),
+            "A": torch.empty(N, device=self.device, dtype=dtype).uniform_(-1000.0, 1000.0),
+            "B": torch.empty(N, device=self.device, dtype=dtype).uniform_(-1000.0, 1000.0),
+            "C": torch.zeros(N, device=self.device, dtype=dtype),
             "N": N,
         }

--- a/challenges/easy/21_relu/challenge.py
+++ b/challenges/easy/21_relu/challenge.py
@@ -6,8 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(name="ReLU", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free")
+    name = "ReLU"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int):
         assert input.shape == (N,)
@@ -27,8 +30,8 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        input_tensor = torch.tensor([-2.0, -1.0, 0.0, 1.0, 2.0], device="cuda", dtype=dtype)
-        output_tensor = torch.empty(5, device="cuda", dtype=dtype)
+        input_tensor = torch.tensor([-2.0, -1.0, 0.0, 1.0, 2.0], device=self.device, dtype=dtype)
+        output_tensor = torch.empty(5, device=self.device, dtype=dtype)
         return {
             "input": input_tensor,
             "output": output_tensor,
@@ -43,8 +46,8 @@ class Challenge(ChallengeBase):
         # Edge case: single element (N=1)
         test_cases.append(
             {
-                "input": torch.tensor([2.0], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([2.0], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1,
             }
         )
@@ -52,8 +55,8 @@ class Challenge(ChallengeBase):
         # Edge case: N=2
         test_cases.append(
             {
-                "input": torch.tensor([-1.0, 1.0], device="cuda", dtype=dtype),
-                "output": torch.empty(2, device="cuda", dtype=dtype),
+                "input": torch.tensor([-1.0, 1.0], device=self.device, dtype=dtype),
+                "output": torch.empty(2, device=self.device, dtype=dtype),
                 "N": 2,
             }
         )
@@ -61,8 +64,8 @@ class Challenge(ChallengeBase):
         # Edge case: N=3
         test_cases.append(
             {
-                "input": torch.tensor([-2.0, 0.0, 2.0], device="cuda", dtype=dtype),
-                "output": torch.empty(3, device="cuda", dtype=dtype),
+                "input": torch.tensor([-2.0, 0.0, 2.0], device=self.device, dtype=dtype),
+                "output": torch.empty(3, device=self.device, dtype=dtype),
                 "N": 3,
             }
         )
@@ -70,32 +73,16 @@ class Challenge(ChallengeBase):
         # Fixed-value test cases
         test_cases.append(
             {
-                "input": torch.tensor([-2.0, -1.0, 0.0, 1.0, 2.0], device="cuda", dtype=dtype),
-                "output": torch.zeros(5, device="cuda", dtype=dtype),
+                "input": torch.tensor([-2.0, -1.0, 0.0, 1.0, 2.0], device=self.device, dtype=dtype),
+                "output": torch.zeros(5, device=self.device, dtype=dtype),
                 "N": 5,
             }
         )
 
         test_cases.append(
             {
-                "input": torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda", dtype=dtype),
-                "output": torch.zeros(5, device="cuda", dtype=dtype),
-                "N": 5,
-            }
-        )
-
-        test_cases.append(
-            {
-                "input": torch.tensor([-1.0, -2.0, -3.0, -4.0, -5.0], device="cuda", dtype=dtype),
-                "output": torch.zeros(5, device="cuda", dtype=dtype),
-                "N": 5,
-            }
-        )
-
-        test_cases.append(
-            {
-                "input": torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0], device="cuda", dtype=dtype),
-                "output": torch.zeros(5, device="cuda", dtype=dtype),
+                "input": torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device=self.device, dtype=dtype),
+                "output": torch.zeros(5, device=self.device, dtype=dtype),
                 "N": 5,
             }
         )
@@ -103,9 +90,17 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "input": torch.tensor(
-                    [-1000.0, -100.0, 0.0, 100.0, 1000.0], device="cuda", dtype=dtype
+                    [-1.0, -2.0, -3.0, -4.0, -5.0], device=self.device, dtype=dtype
                 ),
-                "output": torch.zeros(5, device="cuda", dtype=dtype),
+                "output": torch.zeros(5, device=self.device, dtype=dtype),
+                "N": 5,
+            }
+        )
+
+        test_cases.append(
+            {
+                "input": torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0], device=self.device, dtype=dtype),
+                "output": torch.zeros(5, device=self.device, dtype=dtype),
                 "N": 5,
             }
         )
@@ -113,9 +108,19 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "input": torch.tensor(
-                    [-0.001, -0.0001, 0.0, 0.0001, 0.001], device="cuda", dtype=dtype
+                    [-1000.0, -100.0, 0.0, 100.0, 1000.0], device=self.device, dtype=dtype
                 ),
-                "output": torch.zeros(5, device="cuda", dtype=dtype),
+                "output": torch.zeros(5, device=self.device, dtype=dtype),
+                "N": 5,
+            }
+        )
+
+        test_cases.append(
+            {
+                "input": torch.tensor(
+                    [-0.001, -0.0001, 0.0, 0.0001, 0.001], device=self.device, dtype=dtype
+                ),
+                "output": torch.zeros(5, device=self.device, dtype=dtype),
                 "N": 5,
             }
         )
@@ -123,16 +128,16 @@ class Challenge(ChallengeBase):
         # Random range test cases
         test_cases.append(
             {
-                "input": torch.empty(1024, device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-                "output": torch.zeros(1024, device="cuda", dtype=dtype),
+                "input": torch.empty(1024, device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
+                "output": torch.zeros(1024, device=self.device, dtype=dtype),
                 "N": 1024,
             }
         )
 
         test_cases.append(
             {
-                "input": torch.empty(10000, device="cuda", dtype=dtype).uniform_(-50.0, 50.0),
-                "output": torch.zeros(10000, device="cuda", dtype=dtype),
+                "input": torch.empty(10000, device=self.device, dtype=dtype).uniform_(-50.0, 50.0),
+                "output": torch.zeros(10000, device=self.device, dtype=dtype),
                 "N": 10000,
             }
         )
@@ -143,7 +148,7 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 25000000  # Large vector for performance testing
         return {
-            "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
-            "output": torch.zeros(N, device="cuda", dtype=dtype),
+            "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
+            "output": torch.zeros(N, device=self.device, dtype=dtype),
             "N": N,
         }

--- a/challenges/easy/23_leaky_relu/challenge.py
+++ b/challenges/easy/23_leaky_relu/challenge.py
@@ -6,8 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(name="Leaky ReLU", atol=1e-06, rtol=1e-06, num_gpus=1, access_tier="free")
+    name = "Leaky ReLU"
+    atol = 1e-06
+    rtol = 1e-06
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int):
         assert input.shape == (N,)
@@ -28,8 +31,8 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        input_tensor = torch.tensor([1.0, -2.0, 3.0, -4.0], device="cuda", dtype=dtype)
-        output_tensor = torch.empty(4, device="cuda", dtype=dtype)
+        input_tensor = torch.tensor([1.0, -2.0, 3.0, -4.0], device=self.device, dtype=dtype)
+        output_tensor = torch.empty(4, device=self.device, dtype=dtype)
         return {
             "input": input_tensor,
             "output": output_tensor,
@@ -43,8 +46,8 @@ class Challenge(ChallengeBase):
         # Edge case: single element (N=1)
         test_cases.append(
             {
-                "input": torch.tensor([2.0], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([2.0], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1,
             }
         )
@@ -52,8 +55,8 @@ class Challenge(ChallengeBase):
         # Edge case: N=2
         test_cases.append(
             {
-                "input": torch.tensor([-1.0, 1.0], device="cuda", dtype=dtype),
-                "output": torch.empty(2, device="cuda", dtype=dtype),
+                "input": torch.tensor([-1.0, 1.0], device=self.device, dtype=dtype),
+                "output": torch.empty(2, device=self.device, dtype=dtype),
                 "N": 2,
             }
         )
@@ -61,8 +64,8 @@ class Challenge(ChallengeBase):
         # Edge case: N=3
         test_cases.append(
             {
-                "input": torch.tensor([-2.0, 0.0, 2.0], device="cuda", dtype=dtype),
-                "output": torch.empty(3, device="cuda", dtype=dtype),
+                "input": torch.tensor([-2.0, 0.0, 2.0], device=self.device, dtype=dtype),
+                "output": torch.empty(3, device=self.device, dtype=dtype),
                 "N": 3,
             }
         )
@@ -70,8 +73,8 @@ class Challenge(ChallengeBase):
         # basic_example
         test_cases.append(
             {
-                "input": torch.tensor([1.0, -2.0, 3.0, -4.0], device="cuda", dtype=dtype),
-                "output": torch.zeros(4, device="cuda", dtype=dtype),
+                "input": torch.tensor([1.0, -2.0, 3.0, -4.0], device=self.device, dtype=dtype),
+                "output": torch.zeros(4, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
@@ -79,8 +82,8 @@ class Challenge(ChallengeBase):
         # all_positive
         test_cases.append(
             {
-                "input": torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda", dtype=dtype),
-                "output": torch.zeros(5, device="cuda", dtype=dtype),
+                "input": torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device=self.device, dtype=dtype),
+                "output": torch.zeros(5, device=self.device, dtype=dtype),
                 "N": 5,
             }
         )
@@ -88,8 +91,10 @@ class Challenge(ChallengeBase):
         # all_negative
         test_cases.append(
             {
-                "input": torch.tensor([-1.0, -2.0, -3.0, -4.0, -5.0], device="cuda", dtype=dtype),
-                "output": torch.zeros(5, device="cuda", dtype=dtype),
+                "input": torch.tensor(
+                    [-1.0, -2.0, -3.0, -4.0, -5.0], device=self.device, dtype=dtype
+                ),
+                "output": torch.zeros(5, device=self.device, dtype=dtype),
                 "N": 5,
             }
         )
@@ -97,8 +102,8 @@ class Challenge(ChallengeBase):
         # zeros
         test_cases.append(
             {
-                "input": torch.zeros(1024, device="cuda", dtype=dtype),
-                "output": torch.zeros(1024, device="cuda", dtype=dtype),
+                "input": torch.zeros(1024, device=self.device, dtype=dtype),
+                "output": torch.zeros(1024, device=self.device, dtype=dtype),
                 "N": 1024,
             }
         )
@@ -106,8 +111,10 @@ class Challenge(ChallengeBase):
         # medium_random
         test_cases.append(
             {
-                "input": torch.empty(10000, device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
-                "output": torch.zeros(10000, device="cuda", dtype=dtype),
+                "input": torch.empty(10000, device=self.device, dtype=dtype).uniform_(
+                    -100.0, 100.0
+                ),
+                "output": torch.zeros(10000, device=self.device, dtype=dtype),
                 "N": 10000,
             }
         )
@@ -118,7 +125,7 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 50000000  # Large vector for performance testing
         return {
-            "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0),
-            "output": torch.zeros(N, device="cuda", dtype=dtype),
+            "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-1000.0, 1000.0),
+            "output": torch.zeros(N, device=self.device, dtype=dtype),
             "N": N,
         }

--- a/challenges/easy/24_rainbow_table/challenge.py
+++ b/challenges/easy/24_rainbow_table/challenge.py
@@ -6,8 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(name="Rainbow Table", atol=0, rtol=0, num_gpus=1, access_tier="free")
+    name = "Rainbow Table"
+    atol = 0
+    rtol = 0
+    num_gpus = 1
+    access_tier = "free"
 
     def fnv1a_hash(self, x: torch.Tensor) -> torch.Tensor:
         FNV_PRIME = 16777619
@@ -44,8 +47,8 @@ class Challenge(ChallengeBase):
         }
 
     def generate_example_test(self) -> Dict[str, Any]:
-        input_tensor = torch.tensor([123, 456, 789], device="cuda", dtype=torch.int32)
-        output_tensor = torch.empty(3, device="cuda", dtype=torch.uint32)
+        input_tensor = torch.tensor([123, 456, 789], device=self.device, dtype=torch.int32)
+        output_tensor = torch.empty(3, device=self.device, dtype=torch.uint32)
         return {
             "input": input_tensor,
             "output": output_tensor,
@@ -61,8 +64,8 @@ class Challenge(ChallengeBase):
         # Force users to handle "0 chunks" logic
         test_cases.append(
             {
-                "input": torch.tensor([100], device="cuda", dtype=dtype),
-                "output": torch.zeros(1, device="cuda", dtype=torch.uint32),
+                "input": torch.tensor([100], device=self.device, dtype=dtype),
+                "output": torch.zeros(1, device=self.device, dtype=torch.uint32),
                 "N": 1,
                 "R": 1,
             }
@@ -70,8 +73,8 @@ class Challenge(ChallengeBase):
 
         test_cases.append(
             {
-                "input": torch.tensor([100, 200], device="cuda", dtype=dtype),
-                "output": torch.zeros(2, device="cuda", dtype=torch.uint32),
+                "input": torch.tensor([100, 200], device=self.device, dtype=dtype),
+                "output": torch.zeros(2, device=self.device, dtype=torch.uint32),
                 "N": 2,
                 "R": 1,
             }
@@ -80,8 +83,8 @@ class Challenge(ChallengeBase):
         # basic_example
         test_cases.append(
             {
-                "input": torch.tensor([123, 456, 789], device="cuda", dtype=dtype),
-                "output": torch.zeros(3, device="cuda", dtype=torch.uint32),
+                "input": torch.tensor([123, 456, 789], device=self.device, dtype=dtype),
+                "output": torch.zeros(3, device=self.device, dtype=torch.uint32),
                 "N": 3,
                 "R": 2,
             }
@@ -90,8 +93,8 @@ class Challenge(ChallengeBase):
         # zero_and_max
         test_cases.append(
             {
-                "input": torch.tensor([0, 1, 2147483647], device="cuda", dtype=dtype),
-                "output": torch.zeros(3, device="cuda", dtype=torch.uint32),
+                "input": torch.tensor([0, 1, 2147483647], device=self.device, dtype=dtype),
+                "output": torch.zeros(3, device=self.device, dtype=torch.uint32),
                 "N": 3,
                 "R": 3,
             }
@@ -100,8 +103,8 @@ class Challenge(ChallengeBase):
         # single_round
         test_cases.append(
             {
-                "input": torch.tensor([1, 2, 3, 4, 5], device="cuda", dtype=dtype),
-                "output": torch.zeros(5, device="cuda", dtype=torch.uint32),
+                "input": torch.tensor([1, 2, 3, 4, 5], device=self.device, dtype=dtype),
+                "output": torch.zeros(5, device=self.device, dtype=torch.uint32),
                 "N": 5,
                 "R": 1,
             }
@@ -110,8 +113,8 @@ class Challenge(ChallengeBase):
         # many_rounds
         test_cases.append(
             {
-                "input": torch.randint(0, 2147483647 + 1, (1024,), device="cuda", dtype=dtype),
-                "output": torch.zeros(1024, device="cuda", dtype=torch.uint32),
+                "input": torch.randint(0, 2147483647 + 1, (1024,), device=self.device, dtype=dtype),
+                "output": torch.zeros(1024, device=self.device, dtype=torch.uint32),
                 "N": 1024,
                 "R": 50,
             }
@@ -120,8 +123,10 @@ class Challenge(ChallengeBase):
         # large_size
         test_cases.append(
             {
-                "input": torch.randint(0, 2147483647 + 1, (10000,), device="cuda", dtype=dtype),
-                "output": torch.zeros(10000, device="cuda", dtype=torch.uint32),
+                "input": torch.randint(
+                    0, 2147483647 + 1, (10000,), device=self.device, dtype=dtype
+                ),
+                "output": torch.zeros(10000, device=self.device, dtype=torch.uint32),
                 "N": 10000,
                 "R": 10,
             }
@@ -132,8 +137,8 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         N, R = 5000000, 10  # Large array with moderate rounds for performance testing
         return {
-            "input": torch.randint(0, 2147483647 + 1, (N,), device="cuda", dtype=torch.int32),
-            "output": torch.zeros(N, device="cuda", dtype=torch.uint32),
+            "input": torch.randint(0, 2147483647 + 1, (N,), device=self.device, dtype=torch.int32),
+            "output": torch.zeros(N, device=self.device, dtype=torch.uint32),
             "N": N,
             "R": R,
         }

--- a/challenges/easy/2_matrix_multiplication/challenge.py
+++ b/challenges/easy/2_matrix_multiplication/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Matrix Multiplication", atol=1e-04, rtol=1e-04, num_gpus=1, access_tier="free"
-        )
+    name = "Matrix Multiplication"
+    atol = 0.0001
+    rtol = 0.0001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self, A: torch.Tensor, B: torch.Tensor, C: torch.Tensor, M: int, N: int, K: int
@@ -35,9 +36,9 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         M, N, K = 2, 2, 2
-        A = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="cuda", dtype=dtype)
-        B = torch.tensor([[5.0, 6.0], [7.0, 8.0]], device="cuda", dtype=dtype)
-        C = torch.empty(M, K, device="cuda", dtype=dtype)
+        A = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device=self.device, dtype=dtype)
+        B = torch.tensor([[5.0, 6.0], [7.0, 8.0]], device=self.device, dtype=dtype)
+        C = torch.empty(M, K, device=self.device, dtype=dtype)
         return {
             "A": A,
             "B": B,
@@ -76,9 +77,9 @@ class Challenge(ChallengeBase):
         for _, m, n, k, a_vals, b_vals in test_specs:
             test_cases.append(
                 {
-                    "A": torch.tensor(a_vals, device="cuda", dtype=dtype),
-                    "B": torch.tensor(b_vals, device="cuda", dtype=dtype),
-                    "C": torch.empty(m, k, device="cuda", dtype=dtype),
+                    "A": torch.tensor(a_vals, device=self.device, dtype=dtype),
+                    "B": torch.tensor(b_vals, device=self.device, dtype=dtype),
+                    "C": torch.empty(m, k, device=self.device, dtype=dtype),
                     "M": m,
                     "N": n,
                     "K": k,
@@ -95,9 +96,9 @@ class Challenge(ChallengeBase):
         ]:
             test_cases.append(
                 {
-                    "A": torch.empty(m, n, device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-                    "B": torch.empty(n, k, device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-                    "C": torch.empty(m, k, device="cuda", dtype=dtype),
+                    "A": torch.empty(m, n, device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
+                    "B": torch.empty(n, k, device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
+                    "C": torch.empty(m, k, device=self.device, dtype=dtype),
                     "M": m,
                     "N": n,
                     "K": k,
@@ -113,9 +114,9 @@ class Challenge(ChallengeBase):
         ]:
             test_cases.append(
                 {
-                    "A": torch.empty(m, n, device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                    "B": torch.empty(n, k, device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                    "C": torch.empty(m, k, device="cuda", dtype=dtype),
+                    "A": torch.empty(m, n, device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                    "B": torch.empty(n, k, device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                    "C": torch.empty(m, k, device=self.device, dtype=dtype),
                     "M": m,
                     "N": n,
                     "K": k,
@@ -128,9 +129,9 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         M, N, K = 8192, 6144, 4096
         return {
-            "A": torch.empty(M, N, device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-            "B": torch.empty(N, K, device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-            "C": torch.empty(M, K, device="cuda", dtype=dtype),
+            "A": torch.empty(M, N, device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
+            "B": torch.empty(N, K, device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
+            "C": torch.empty(M, K, device=self.device, dtype=dtype),
             "M": M,
             "N": N,
             "K": K,

--- a/challenges/easy/31_matrix_copy/challenge.py
+++ b/challenges/easy/31_matrix_copy/challenge.py
@@ -6,8 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(name="Matrix Copy", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free")
+    name = "Matrix Copy"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, A: torch.Tensor, B: torch.Tensor, N: int):
         assert A.shape == (N, N)
@@ -27,8 +30,8 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        A = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="cuda", dtype=dtype)
-        B = torch.empty(2, 2, device="cuda", dtype=dtype)
+        A = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device=self.device, dtype=dtype)
+        B = torch.empty(2, 2, device=self.device, dtype=dtype)
         return {
             "A": A,
             "B": B,
@@ -43,8 +46,8 @@ class Challenge(ChallengeBase):
         # basic_2x2
         test_cases.append(
             {
-                "A": torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="cuda", dtype=dtype),
-                "B": torch.zeros((2, 2), device="cuda", dtype=dtype),
+                "A": torch.tensor([[1.0, 2.0], [3.0, 4.0]], device=self.device, dtype=dtype),
+                "B": torch.zeros((2, 2), device=self.device, dtype=dtype),
                 "N": 2,
             }
         )
@@ -52,8 +55,8 @@ class Challenge(ChallengeBase):
         # all_zeros_4x4
         test_cases.append(
             {
-                "A": torch.zeros((4, 4), device="cuda", dtype=dtype),
-                "B": torch.zeros((4, 4), device="cuda", dtype=dtype),
+                "A": torch.zeros((4, 4), device=self.device, dtype=dtype),
+                "B": torch.zeros((4, 4), device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
@@ -62,9 +65,11 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "A": torch.tensor(
-                    [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], device="cuda", dtype=dtype
+                    [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+                    device=self.device,
+                    dtype=dtype,
                 ),
-                "B": torch.zeros((3, 3), device="cuda", dtype=dtype),
+                "B": torch.zeros((3, 3), device=self.device, dtype=dtype),
                 "N": 3,
             }
         )
@@ -72,8 +77,8 @@ class Challenge(ChallengeBase):
         # negative_values_2x2
         test_cases.append(
             {
-                "A": torch.tensor([[-1.0, -2.0], [-3.0, -4.0]], device="cuda", dtype=dtype),
-                "B": torch.zeros((2, 2), device="cuda", dtype=dtype),
+                "A": torch.tensor([[-1.0, -2.0], [-3.0, -4.0]], device=self.device, dtype=dtype),
+                "B": torch.zeros((2, 2), device=self.device, dtype=dtype),
                 "N": 2,
             }
         )
@@ -81,8 +86,8 @@ class Challenge(ChallengeBase):
         # large_N_16x16
         test_cases.append(
             {
-                "A": torch.empty((16, 16), device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-                "B": torch.zeros((16, 16), device="cuda", dtype=dtype),
+                "A": torch.empty((16, 16), device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
+                "B": torch.zeros((16, 16), device=self.device, dtype=dtype),
                 "N": 16,
             }
         )
@@ -90,8 +95,8 @@ class Challenge(ChallengeBase):
         # single_element
         test_cases.append(
             {
-                "A": torch.tensor([[42.0]], device="cuda", dtype=dtype),
-                "B": torch.zeros((1, 1), device="cuda", dtype=dtype),
+                "A": torch.tensor([[42.0]], device=self.device, dtype=dtype),
+                "B": torch.zeros((1, 1), device=self.device, dtype=dtype),
                 "N": 1,
             }
         )
@@ -102,7 +107,7 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 4096
         return {
-            "A": torch.empty(N, N, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0),
-            "B": torch.empty(N, N, device="cuda", dtype=dtype),
+            "A": torch.empty(N, N, device=self.device, dtype=dtype).uniform_(-1000.0, 1000.0),
+            "B": torch.empty(N, N, device=self.device, dtype=dtype),
             "N": N,
         }

--- a/challenges/easy/3_matrix_transpose/challenge.py
+++ b/challenges/easy/3_matrix_transpose/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Matrix Transpose", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Matrix Transpose"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, rows: int, cols: int):
         assert input.shape == (rows, cols)
@@ -30,8 +31,10 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         rows, cols = 2, 3
-        input_tensor = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device="cuda", dtype=dtype)
-        output_tensor = torch.empty(cols, rows, device="cuda", dtype=dtype)
+        input_tensor = torch.tensor(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device=self.device, dtype=dtype
+        )
+        output_tensor = torch.empty(cols, rows, device=self.device, dtype=dtype)
         return {
             "input": input_tensor,
             "output": output_tensor,
@@ -54,8 +57,8 @@ class Challenge(ChallengeBase):
         for _, r, c, input_vals in test_specs:
             test_cases.append(
                 {
-                    "input": torch.tensor(input_vals, device="cuda", dtype=dtype),
-                    "output": torch.empty(c, r, device="cuda", dtype=dtype),
+                    "input": torch.tensor(input_vals, device=self.device, dtype=dtype),
+                    "output": torch.empty(c, r, device=self.device, dtype=dtype),
                     "rows": r,
                     "cols": c,
                 }
@@ -71,10 +74,10 @@ class Challenge(ChallengeBase):
         ]:
             test_cases.append(
                 {
-                    "input": torch.empty(rows, cols, device="cuda", dtype=dtype).uniform_(
+                    "input": torch.empty(rows, cols, device=self.device, dtype=dtype).uniform_(
                         -10.0, 10.0
                     ),
-                    "output": torch.empty(cols, rows, device="cuda", dtype=dtype),
+                    "output": torch.empty(cols, rows, device=self.device, dtype=dtype),
                     "rows": rows,
                     "cols": cols,
                 }
@@ -87,10 +90,10 @@ class Challenge(ChallengeBase):
         ]:
             test_cases.append(
                 {
-                    "input": torch.empty(rows, cols, device="cuda", dtype=dtype).uniform_(
+                    "input": torch.empty(rows, cols, device=self.device, dtype=dtype).uniform_(
                         -1.0, 1.0
                     ),
-                    "output": torch.empty(cols, rows, device="cuda", dtype=dtype),
+                    "output": torch.empty(cols, rows, device=self.device, dtype=dtype),
                     "rows": rows,
                     "cols": cols,
                 }
@@ -102,8 +105,8 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         rows, cols = 7000, 6000
         return {
-            "input": torch.empty(rows, cols, device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-            "output": torch.zeros(cols, rows, device="cuda", dtype=dtype),
+            "input": torch.empty(rows, cols, device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
+            "output": torch.zeros(cols, rows, device=self.device, dtype=dtype),
             "rows": rows,
             "cols": cols,
         }

--- a/challenges/easy/41_simple_inference/challenge.py
+++ b/challenges/easy/41_simple_inference/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Simple Inference", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Simple Inference"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, model: nn.Module, output: torch.Tensor):
         assert input.device == output.device
@@ -28,7 +29,7 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
 
         # Create a simple linear model
         model = nn.Linear(2, 2)
@@ -47,7 +48,7 @@ class Challenge(ChallengeBase):
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         tests = []
 
         # Test 1: Basic 2->2 linear layer
@@ -169,7 +170,7 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
 
         # Large model for performance testing
         model = nn.Linear(512, 256)

--- a/challenges/easy/52_silu/challenge.py
+++ b/challenges/easy/52_silu/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Sigmoid Linear Unit", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Sigmoid Linear Unit"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int):
         assert input.shape == output.shape == (N,)
@@ -29,8 +30,8 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 4
-        input = torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype)
-        output = torch.empty(N, device="cuda", dtype=dtype)
+        input = torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype)
+        output = torch.empty(N, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,
@@ -45,8 +46,8 @@ class Challenge(ChallengeBase):
         N = 3
         tests.append(
             {
-                "input": torch.tensor([0.5, 1.0, -0.5], device="cuda", dtype=dtype),
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "input": torch.tensor([0.5, 1.0, -0.5], device=self.device, dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -55,8 +56,8 @@ class Challenge(ChallengeBase):
         N = 1
         tests.append(
             {
-                "input": torch.tensor([2.0], device="cuda", dtype=dtype),
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "input": torch.tensor([2.0], device=self.device, dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -65,8 +66,8 @@ class Challenge(ChallengeBase):
         N = 42
         tests.append(
             {
-                "input": torch.zeros(N, device="cuda", dtype=dtype),
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "input": torch.zeros(N, device=self.device, dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -75,8 +76,10 @@ class Challenge(ChallengeBase):
         N = 5
         tests.append(
             {
-                "input": torch.tensor([-1.0, -2.0, -3.0, -4.0, -5.0], device="cuda", dtype=dtype),
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "input": torch.tensor(
+                    [-1.0, -2.0, -3.0, -4.0, -5.0], device=self.device, dtype=dtype
+                ),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -85,8 +88,8 @@ class Challenge(ChallengeBase):
         N = 4
         tests.append(
             {
-                "input": torch.tensor([-0.5, 0.0, 0.5, 1.0], device="cuda", dtype=dtype),
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "input": torch.tensor([-0.5, 0.0, 0.5, 1.0], device=self.device, dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -95,8 +98,8 @@ class Challenge(ChallengeBase):
         N = 1024
         tests.append(
             {
-                "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -105,8 +108,8 @@ class Challenge(ChallengeBase):
         N = 10000
         tests.append(
             {
-                "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-50.0, 50.0),
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-50.0, 50.0),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -117,7 +120,7 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 50000
         return {
-            "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-50.0, 50.0),
-            "output": torch.empty(N, device="cuda", dtype=dtype),
+            "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-50.0, 50.0),
+            "output": torch.empty(N, device=self.device, dtype=dtype),
             "N": N,
         }

--- a/challenges/easy/54_swiglu/challenge.py
+++ b/challenges/easy/54_swiglu/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Swish-Gated Linear Unit", atol=1e-04, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Swish-Gated Linear Unit"
+    atol = 0.0001
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int):
         assert N % 2 == 0
@@ -31,8 +32,8 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 4
-        input = torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype)
-        output = torch.empty(N // 2, device="cuda", dtype=dtype)
+        input = torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype)
+        output = torch.empty(N // 2, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,
@@ -47,8 +48,8 @@ class Challenge(ChallengeBase):
         N = 2
         tests.append(
             {
-                "input": torch.tensor([0.5, 1.0], device="cuda", dtype=dtype),
-                "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+                "input": torch.tensor([0.5, 1.0], device=self.device, dtype=dtype),
+                "output": torch.empty(N // 2, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -57,8 +58,8 @@ class Challenge(ChallengeBase):
         N = 42
         tests.append(
             {
-                "input": torch.zeros(N, device="cuda", dtype=dtype),
-                "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+                "input": torch.zeros(N, device=self.device, dtype=dtype),
+                "output": torch.empty(N // 2, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -68,9 +69,9 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "input": torch.tensor(
-                    [-1.0, -2.0, -3.0, -4.0, -5.0, -6.0], device="cuda", dtype=dtype
+                    [-1.0, -2.0, -3.0, -4.0, -5.0, -6.0], device=self.device, dtype=dtype
                 ),
-                "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+                "output": torch.empty(N // 2, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -79,8 +80,8 @@ class Challenge(ChallengeBase):
         N = 4
         tests.append(
             {
-                "input": torch.tensor([-0.5, 0.0, -1.5, 1.0], device="cuda", dtype=dtype),
-                "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+                "input": torch.tensor([-0.5, 0.0, -1.5, 1.0], device=self.device, dtype=dtype),
+                "output": torch.empty(N // 2, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -89,8 +90,8 @@ class Challenge(ChallengeBase):
         N = 1024
         tests.append(
             {
-                "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
-                "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+                "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
+                "output": torch.empty(N // 2, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -99,8 +100,8 @@ class Challenge(ChallengeBase):
         N = 2048
         tests.append(
             {
-                "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-50.0, 50.0),
-                "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+                "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-50.0, 50.0),
+                "output": torch.empty(N // 2, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -111,7 +112,7 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 100000
         return {
-            "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
-            "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+            "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
+            "output": torch.empty(N // 2, device=self.device, dtype=dtype),
             "N": N,
         }

--- a/challenges/easy/62_value_clipping/challenge.py
+++ b/challenges/easy/62_value_clipping/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Value Clipping", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Value Clipping"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self, input: torch.Tensor, output: torch.Tensor, lo: float, hi: float, N: int
@@ -32,8 +33,8 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 4
-        input = torch.tensor([1.5, -2.0, 3.0, 4.5], device="cuda", dtype=dtype)
-        output = torch.empty(N, device="cuda", dtype=dtype)
+        input = torch.tensor([1.5, -2.0, 3.0, 4.5], device=self.device, dtype=dtype)
+        output = torch.empty(N, device=self.device, dtype=dtype)
         lo, hi = 0.0, 3.5
         return {"input": input, "output": output, "lo": lo, "hi": hi, "N": N}
 
@@ -45,8 +46,8 @@ class Challenge(ChallengeBase):
         N = 3
         tests.append(
             {
-                "input": torch.tensor([-1.0, 2.0, 5.0], device="cuda", dtype=dtype),
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "input": torch.tensor([-1.0, 2.0, 5.0], device=self.device, dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "lo": -0.5,
                 "hi": 2.5,
                 "N": N,
@@ -57,8 +58,8 @@ class Challenge(ChallengeBase):
         N = 42
         tests.append(
             {
-                "input": torch.zeros(N, device="cuda", dtype=dtype),
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "input": torch.zeros(N, device=self.device, dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "lo": -1.0,
                 "hi": 1.0,
                 "N": N,
@@ -70,9 +71,9 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "input": torch.tensor(
-                    [-1.0, -2.0, -3.0, -4.0, -5.0, -6.0], device="cuda", dtype=dtype
+                    [-1.0, -2.0, -3.0, -4.0, -5.0, -6.0], device=self.device, dtype=dtype
                 ),
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "lo": -3.0,
                 "hi": -1.0,
                 "N": N,
@@ -83,8 +84,8 @@ class Challenge(ChallengeBase):
         N = 4
         tests.append(
             {
-                "input": torch.tensor([-0.5, 0.0, -1.5, 1.0], device="cuda", dtype=dtype),
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "input": torch.tensor([-0.5, 0.0, -1.5, 1.0], device=self.device, dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "lo": -1.0,
                 "hi": 0.5,
                 "N": N,
@@ -95,8 +96,8 @@ class Challenge(ChallengeBase):
         N = 1024
         tests.append(
             {
-                "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "lo": -50.9,
                 "hi": 50.1,
                 "N": N,
@@ -107,8 +108,8 @@ class Challenge(ChallengeBase):
         N = 2048
         tests.append(
             {
-                "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-50.0, 50.0),
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-50.0, 50.0),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "lo": -25.5,
                 "hi": 25.05,
                 "N": N,
@@ -121,8 +122,8 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 100000
         return {
-            "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
-            "output": torch.empty(N, device="cuda", dtype=dtype),
+            "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
+            "output": torch.empty(N, device=self.device, dtype=dtype),
             "lo": -51.24,
             "hi": 39.51,
             "N": N,

--- a/challenges/easy/63_interleave/challenge.py
+++ b/challenges/easy/63_interleave/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Interleave Arrays", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Interleave Arrays"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, A: torch.Tensor, B: torch.Tensor, output: torch.Tensor, N: int):
         assert A.shape == (N,)
@@ -31,9 +32,9 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        A = torch.tensor([1.0, 2.0, 3.0], device="cuda", dtype=dtype)
-        B = torch.tensor([4.0, 5.0, 6.0], device="cuda", dtype=dtype)
-        output = torch.empty(6, device="cuda", dtype=dtype)
+        A = torch.tensor([1.0, 2.0, 3.0], device=self.device, dtype=dtype)
+        B = torch.tensor([4.0, 5.0, 6.0], device=self.device, dtype=dtype)
+        output = torch.empty(6, device=self.device, dtype=dtype)
         return {
             "A": A,
             "B": B,
@@ -48,9 +49,9 @@ class Challenge(ChallengeBase):
         # Basic example
         tests.append(
             {
-                "A": torch.tensor([1.0, 2.0, 3.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([4.0, 5.0, 6.0], device="cuda", dtype=dtype),
-                "output": torch.empty(6, device="cuda", dtype=dtype),
+                "A": torch.tensor([1.0, 2.0, 3.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([4.0, 5.0, 6.0], device=self.device, dtype=dtype),
+                "output": torch.empty(6, device=self.device, dtype=dtype),
                 "N": 3,
             }
         )
@@ -58,9 +59,9 @@ class Challenge(ChallengeBase):
         # Single element
         tests.append(
             {
-                "A": torch.tensor([1.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([2.0], device="cuda", dtype=dtype),
-                "output": torch.empty(2, device="cuda", dtype=dtype),
+                "A": torch.tensor([1.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([2.0], device=self.device, dtype=dtype),
+                "output": torch.empty(2, device=self.device, dtype=dtype),
                 "N": 1,
             }
         )
@@ -68,9 +69,9 @@ class Challenge(ChallengeBase):
         # Two elements
         tests.append(
             {
-                "A": torch.tensor([10.0, 20.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([30.0, 40.0], device="cuda", dtype=dtype),
-                "output": torch.empty(4, device="cuda", dtype=dtype),
+                "A": torch.tensor([10.0, 20.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([30.0, 40.0], device=self.device, dtype=dtype),
+                "output": torch.empty(4, device=self.device, dtype=dtype),
                 "N": 2,
             }
         )
@@ -78,9 +79,9 @@ class Challenge(ChallengeBase):
         # Negative values
         tests.append(
             {
-                "A": torch.tensor([-1.0, -2.0, -3.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([-4.0, -5.0, -6.0], device="cuda", dtype=dtype),
-                "output": torch.empty(6, device="cuda", dtype=dtype),
+                "A": torch.tensor([-1.0, -2.0, -3.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([-4.0, -5.0, -6.0], device=self.device, dtype=dtype),
+                "output": torch.empty(6, device=self.device, dtype=dtype),
                 "N": 3,
             }
         )
@@ -88,9 +89,9 @@ class Challenge(ChallengeBase):
         # Mixed positive and negative
         tests.append(
             {
-                "A": torch.tensor([1.0, -2.0, 3.0, -4.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([-1.0, 2.0, -3.0, 4.0], device="cuda", dtype=dtype),
-                "output": torch.empty(8, device="cuda", dtype=dtype),
+                "A": torch.tensor([1.0, -2.0, 3.0, -4.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([-1.0, 2.0, -3.0, 4.0], device=self.device, dtype=dtype),
+                "output": torch.empty(8, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
@@ -98,9 +99,9 @@ class Challenge(ChallengeBase):
         # Zeros
         tests.append(
             {
-                "A": torch.zeros(5, device="cuda", dtype=dtype),
-                "B": torch.ones(5, device="cuda", dtype=dtype),
-                "output": torch.empty(10, device="cuda", dtype=dtype),
+                "A": torch.zeros(5, device=self.device, dtype=dtype),
+                "B": torch.ones(5, device=self.device, dtype=dtype),
+                "output": torch.empty(10, device=self.device, dtype=dtype),
                 "N": 5,
             }
         )
@@ -108,9 +109,9 @@ class Challenge(ChallengeBase):
         # Large values
         tests.append(
             {
-                "A": torch.tensor([1e10, 1e-10], device="cuda", dtype=dtype),
-                "B": torch.tensor([1e-10, 1e10], device="cuda", dtype=dtype),
-                "output": torch.empty(4, device="cuda", dtype=dtype),
+                "A": torch.tensor([1e10, 1e-10], device=self.device, dtype=dtype),
+                "B": torch.tensor([1e-10, 1e10], device=self.device, dtype=dtype),
+                "output": torch.empty(4, device=self.device, dtype=dtype),
                 "N": 2,
             }
         )
@@ -119,9 +120,9 @@ class Challenge(ChallengeBase):
         N = 1024
         tests.append(
             {
-                "A": torch.randn(N, device="cuda", dtype=dtype),
-                "B": torch.randn(N, device="cuda", dtype=dtype),
-                "output": torch.empty(2 * N, device="cuda", dtype=dtype),
+                "A": torch.randn(N, device=self.device, dtype=dtype),
+                "B": torch.randn(N, device=self.device, dtype=dtype),
+                "output": torch.empty(2 * N, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -130,9 +131,9 @@ class Challenge(ChallengeBase):
         N = 10000
         tests.append(
             {
-                "A": torch.randn(N, device="cuda", dtype=dtype),
-                "B": torch.randn(N, device="cuda", dtype=dtype),
-                "output": torch.empty(2 * N, device="cuda", dtype=dtype),
+                "A": torch.randn(N, device=self.device, dtype=dtype),
+                "B": torch.randn(N, device=self.device, dtype=dtype),
+                "output": torch.empty(2 * N, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -141,9 +142,9 @@ class Challenge(ChallengeBase):
         N = 100000
         tests.append(
             {
-                "A": torch.randn(N, device="cuda", dtype=dtype),
-                "B": torch.randn(N, device="cuda", dtype=dtype),
-                "output": torch.empty(2 * N, device="cuda", dtype=dtype),
+                "A": torch.randn(N, device=self.device, dtype=dtype),
+                "B": torch.randn(N, device=self.device, dtype=dtype),
+                "output": torch.empty(2 * N, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -154,8 +155,8 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 25000000  # 25 million elements each, 50 million output
         return {
-            "A": torch.randn(N, device="cuda", dtype=dtype),
-            "B": torch.randn(N, device="cuda", dtype=dtype),
-            "output": torch.empty(2 * N, device="cuda", dtype=dtype),
+            "A": torch.randn(N, device=self.device, dtype=dtype),
+            "B": torch.randn(N, device=self.device, dtype=dtype),
+            "output": torch.empty(2 * N, device=self.device, dtype=dtype),
             "N": N,
         }

--- a/challenges/easy/65_geglu/challenge.py
+++ b/challenges/easy/65_geglu/challenge.py
@@ -7,14 +7,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Gaussian Error Gated Linear Unit",
-            atol=1e-04,
-            rtol=1e-04,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Gaussian Error Gated Linear Unit"
+    atol = 0.0001
+    rtol = 0.0001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int):
         assert N % 2 == 0
@@ -37,8 +34,8 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 2
-        input = torch.tensor([1.0, 1.0], device="cuda", dtype=dtype)
-        output = torch.empty(N // 2, device="cuda", dtype=dtype)
+        input = torch.tensor([1.0, 1.0], device=self.device, dtype=dtype)
+        output = torch.empty(N // 2, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,
@@ -53,8 +50,8 @@ class Challenge(ChallengeBase):
         N = 4
         tests.append(
             {
-                "input": torch.tensor([2.0, -1.0, 1.0, 0.5], device="cuda", dtype=dtype),
-                "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+                "input": torch.tensor([2.0, -1.0, 1.0, 0.5], device=self.device, dtype=dtype),
+                "output": torch.empty(N // 2, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -63,8 +60,8 @@ class Challenge(ChallengeBase):
         N = 42
         tests.append(
             {
-                "input": torch.zeros(N, device="cuda", dtype=dtype),
-                "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+                "input": torch.zeros(N, device=self.device, dtype=dtype),
+                "output": torch.empty(N // 2, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -74,9 +71,9 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "input": torch.tensor(
-                    [-1.0, -2.0, -3.0, -4.0, -5.0, -6.0], device="cuda", dtype=dtype
+                    [-1.0, -2.0, -3.0, -4.0, -5.0, -6.0], device=self.device, dtype=dtype
                 ),
-                "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+                "output": torch.empty(N // 2, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -85,8 +82,8 @@ class Challenge(ChallengeBase):
         N = 4
         tests.append(
             {
-                "input": torch.tensor([-0.5, 0.0, -1.5, 1.0], device="cuda", dtype=dtype),
-                "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+                "input": torch.tensor([-0.5, 0.0, -1.5, 1.0], device=self.device, dtype=dtype),
+                "output": torch.empty(N // 2, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -95,8 +92,8 @@ class Challenge(ChallengeBase):
         N = 1024
         tests.append(
             {
-                "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
-                "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+                "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
+                "output": torch.empty(N // 2, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -105,8 +102,8 @@ class Challenge(ChallengeBase):
         N = 100000
         tests.append(
             {
-                "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-50.0, 50.0),
-                "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+                "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-50.0, 50.0),
+                "output": torch.empty(N // 2, device=self.device, dtype=dtype),
                 "N": N,
             }
         )
@@ -117,7 +114,7 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 1000000
         return {
-            "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
-            "output": torch.empty(N // 2, device="cuda", dtype=dtype),
+            "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
+            "output": torch.empty(N // 2, device=self.device, dtype=dtype),
             "N": N,
         }

--- a/challenges/easy/66_rgb_to_grayscale/challenge.py
+++ b/challenges/easy/66_rgb_to_grayscale/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="RGB to Grayscale", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "RGB to Grayscale"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, width: int, height: int):
         assert input.shape == (height * width * 3,)
@@ -58,10 +59,10 @@ class Challenge(ChallengeBase):
                 128.0,
                 128.0,  # gray
             ],
-            device="cuda",
+            device=self.device,
             dtype=torch.float32,
         )
-        output = torch.zeros(width * height, device="cuda", dtype=torch.float32)
+        output = torch.zeros(width * height, device=self.device, dtype=torch.float32)
         return {
             "input": input_data,
             "output": output,
@@ -76,9 +77,9 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "input": torch.tensor(
-                    [255.0, 0.0, 0.0], device="cuda", dtype=torch.float32
+                    [255.0, 0.0, 0.0], device=self.device, dtype=torch.float32
                 ),  # red pixel
-                "output": torch.zeros(1, device="cuda", dtype=torch.float32),
+                "output": torch.zeros(1, device=self.device, dtype=torch.float32),
                 "width": 1,
                 "height": 1,
             }
@@ -87,9 +88,9 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "input": torch.tensor(
-                    [0.0, 255.0, 0.0], device="cuda", dtype=torch.float32
+                    [0.0, 255.0, 0.0], device=self.device, dtype=torch.float32
                 ),  # green pixel
-                "output": torch.zeros(1, device="cuda", dtype=torch.float32),
+                "output": torch.zeros(1, device=self.device, dtype=torch.float32),
                 "width": 1,
                 "height": 1,
             }
@@ -98,9 +99,9 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "input": torch.tensor(
-                    [0.0, 0.0, 255.0], device="cuda", dtype=torch.float32
+                    [0.0, 0.0, 255.0], device=self.device, dtype=torch.float32
                 ),  # blue pixel
-                "output": torch.zeros(1, device="cuda", dtype=torch.float32),
+                "output": torch.zeros(1, device=self.device, dtype=torch.float32),
                 "width": 1,
                 "height": 1,
             }
@@ -124,10 +125,10 @@ class Challenge(ChallengeBase):
                         125.0,
                         175.0,  # mixed color 4
                     ],
-                    device="cuda",
+                    device=self.device,
                     dtype=torch.float32,
                 ),
-                "output": torch.zeros(4, device="cuda", dtype=torch.float32),
+                "output": torch.zeros(4, device=self.device, dtype=torch.float32),
                 "width": 2,
                 "height": 2,
             }
@@ -136,8 +137,8 @@ class Challenge(ChallengeBase):
         # Edge cases: zeros and max values
         test_cases.append(
             {
-                "input": torch.zeros(3, device="cuda", dtype=torch.float32),
-                "output": torch.zeros(1, device="cuda", dtype=torch.float32),
+                "input": torch.zeros(3, device=self.device, dtype=torch.float32),
+                "output": torch.zeros(1, device=self.device, dtype=torch.float32),
                 "width": 1,
                 "height": 1,
             }
@@ -145,8 +146,8 @@ class Challenge(ChallengeBase):
 
         test_cases.append(
             {
-                "input": torch.full((3,), 255.0, device="cuda", dtype=torch.float32),
-                "output": torch.zeros(1, device="cuda", dtype=torch.float32),
+                "input": torch.full((3,), 255.0, device=self.device, dtype=torch.float32),
+                "output": torch.zeros(1, device=self.device, dtype=torch.float32),
                 "width": 1,
                 "height": 1,
             }
@@ -158,9 +159,9 @@ class Challenge(ChallengeBase):
             test_cases.append(
                 {
                     "input": torch.randint(
-                        0, 256, (input_size,), device="cuda", dtype=torch.float32
+                        0, 256, (input_size,), device=self.device, dtype=torch.float32
                     ),
-                    "output": torch.zeros(size * size, device="cuda", dtype=torch.float32),
+                    "output": torch.zeros(size * size, device=self.device, dtype=torch.float32),
                     "width": size,
                     "height": size,
                 }
@@ -170,10 +171,10 @@ class Challenge(ChallengeBase):
         for w, h in [(100, 100), (64, 48)]:
             test_cases.append(
                 {
-                    "input": torch.empty(h * w * 3, device="cuda", dtype=torch.float32).uniform_(
-                        0.0, 255.0
-                    ),
-                    "output": torch.zeros(h * w, device="cuda", dtype=torch.float32),
+                    "input": torch.empty(
+                        h * w * 3, device=self.device, dtype=torch.float32
+                    ).uniform_(0.0, 255.0),
+                    "output": torch.zeros(h * w, device=self.device, dtype=torch.float32),
                     "width": w,
                     "height": h,
                 }
@@ -183,9 +184,9 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "input": torch.randint(
-                    0, 256, (2 * 3 * 3,), device="cuda", dtype=torch.float32
+                    0, 256, (2 * 3 * 3,), device=self.device, dtype=torch.float32
                 ),  # 2x3 image
-                "output": torch.zeros(2 * 3, device="cuda", dtype=torch.float32),
+                "output": torch.zeros(2 * 3, device=self.device, dtype=torch.float32),
                 "width": 3,
                 "height": 2,
             }
@@ -194,9 +195,9 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "input": torch.randint(
-                    0, 256, (3 * 2 * 3,), device="cuda", dtype=torch.float32
+                    0, 256, (3 * 2 * 3,), device=self.device, dtype=torch.float32
                 ),  # 3x2 image
-                "output": torch.zeros(3 * 2, device="cuda", dtype=torch.float32),
+                "output": torch.zeros(3 * 2, device=self.device, dtype=torch.float32),
                 "width": 2,
                 "height": 3,
             }
@@ -209,8 +210,8 @@ class Challenge(ChallengeBase):
         input_size = width * height * 3
         output_size = width * height
         return {
-            "input": torch.randint(0, 256, (input_size,), device="cuda", dtype=torch.float32),
-            "output": torch.zeros(output_size, device="cuda", dtype=torch.float32),
+            "input": torch.randint(0, 256, (input_size,), device=self.device, dtype=torch.float32),
+            "output": torch.zeros(output_size, device=self.device, dtype=torch.float32),
             "width": width,
             "height": height,
         }

--- a/challenges/easy/68_sigmoid/challenge.py
+++ b/challenges/easy/68_sigmoid/challenge.py
@@ -6,17 +6,16 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Sigmoid Activation", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Sigmoid Activation"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, X: torch.Tensor, Y: torch.Tensor, N: int):
         assert X.shape == Y.shape
         assert X.dtype == torch.float32
         assert Y.dtype == torch.float32
-        assert X.device.type == "cuda"
-        assert Y.device.type == "cuda"
 
         torch.sigmoid(X, out=Y)
 
@@ -30,8 +29,8 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 4
-        X = torch.tensor([0.0, 1.0, -1.0, 2.0], device="cuda", dtype=dtype)
-        Y = torch.empty(N, device="cuda", dtype=dtype)
+        X = torch.tensor([0.0, 1.0, -1.0, 2.0], device=self.device, dtype=dtype)
+        Y = torch.empty(N, device=self.device, dtype=dtype)
         return {
             "X": X,
             "Y": Y,
@@ -57,8 +56,8 @@ class Challenge(ChallengeBase):
             n = len(x_vals)
             test_cases.append(
                 {
-                    "X": torch.tensor(x_vals, device="cuda", dtype=dtype),
-                    "Y": torch.empty(n, device="cuda", dtype=dtype),
+                    "X": torch.tensor(x_vals, device=self.device, dtype=dtype),
+                    "Y": torch.empty(n, device=self.device, dtype=dtype),
                     "N": n,
                 }
             )
@@ -73,8 +72,8 @@ class Challenge(ChallengeBase):
         ]:
             test_cases.append(
                 {
-                    "X": torch.empty(size, device="cuda", dtype=dtype).uniform_(low, high),
-                    "Y": torch.empty(size, device="cuda", dtype=dtype),
+                    "X": torch.empty(size, device=self.device, dtype=dtype).uniform_(low, high),
+                    "Y": torch.empty(size, device=self.device, dtype=dtype),
                     "N": size,
                 }
             )
@@ -85,7 +84,7 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 50000000
         return {
-            "X": torch.empty(N, device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-            "Y": torch.empty(N, device="cuda", dtype=dtype),
+            "X": torch.empty(N, device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
+            "Y": torch.empty(N, device=self.device, dtype=dtype),
             "N": N,
         }

--- a/challenges/easy/7_color_inversion/challenge.py
+++ b/challenges/easy/7_color_inversion/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Color Inversion", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Color Inversion"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, image: torch.Tensor, width: int, height: int):
         assert image.shape == (height * width * 4,)
@@ -30,7 +31,9 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         width, height = 1, 2
-        image = torch.tensor([255, 0, 128, 255, 0, 255, 0, 255], device="cuda", dtype=torch.uint8)
+        image = torch.tensor(
+            [255, 0, 128, 255, 0, 255, 0, 255], device=self.device, dtype=torch.uint8
+        )
         return {
             "image": image,
             "width": width,
@@ -46,25 +49,27 @@ class Challenge(ChallengeBase):
                         [[0, 0, 255, 255], [128, 128, 128, 255]],
                     ],
                     dtype=torch.uint8,
-                    device="cuda",
+                    device=self.device,
                 ).flatten(),
                 "width": 2,
                 "height": 2,
             },
             {
                 "image": torch.tensor(
-                    [[[100, 50, 200, 255]]], dtype=torch.uint8, device="cuda"
+                    [[[100, 50, 200, 255]]], dtype=torch.uint8, device=self.device
                 ).flatten(),
                 "width": 1,
                 "height": 1,
             },
             {
-                "image": torch.zeros((3, 4, 4), dtype=torch.uint8, device="cuda").flatten(),
+                "image": torch.zeros((3, 4, 4), dtype=torch.uint8, device=self.device).flatten(),
                 "width": 4,
                 "height": 3,
             },
             {
-                "image": torch.full((5, 3, 4), 255, dtype=torch.uint8, device="cuda").flatten(),
+                "image": torch.full(
+                    (5, 3, 4), 255, dtype=torch.uint8, device=self.device
+                ).flatten(),
                 "width": 3,
                 "height": 5,
             },
@@ -75,18 +80,22 @@ class Challenge(ChallengeBase):
                         [[70, 80, 90, 150], [100, 110, 120, 200]],
                     ],
                     dtype=torch.uint8,
-                    device="cuda",
+                    device=self.device,
                 ).flatten(),
                 "width": 2,
                 "height": 2,
             },
             {
-                "image": torch.randint(0, 256, (64 * 64 * 4,), dtype=torch.uint8, device="cuda"),
+                "image": torch.randint(
+                    0, 256, (64 * 64 * 4,), dtype=torch.uint8, device=self.device
+                ),
                 "width": 64,
                 "height": 64,
             },
             {
-                "image": torch.randint(0, 256, (32 * 64 * 4,), dtype=torch.uint8, device="cuda"),
+                "image": torch.randint(
+                    0, 256, (32 * 64 * 4,), dtype=torch.uint8, device=self.device
+                ),
                 "width": 64,
                 "height": 32,
             },
@@ -96,7 +105,7 @@ class Challenge(ChallengeBase):
         width, height = 4096, 5120
         size = width * height * 4
         return {
-            "image": torch.randint(0, 256, (size,), device="cuda", dtype=torch.uint8),
+            "image": torch.randint(0, 256, (size,), device=self.device, dtype=torch.uint8),
             "width": width,
             "height": height,
         }

--- a/challenges/easy/8_matrix_addition/challenge.py
+++ b/challenges/easy/8_matrix_addition/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Matrix Addition", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Matrix Addition"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, A: torch.Tensor, B: torch.Tensor, C: torch.Tensor, N: int):
         assert A.shape == (N, N)
@@ -31,9 +32,9 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 2
-        A = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="cuda", dtype=dtype)
-        B = torch.tensor([[5.0, 6.0], [7.0, 8.0]], device="cuda", dtype=dtype)
-        C = torch.empty(N, N, device="cuda", dtype=dtype)
+        A = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device=self.device, dtype=dtype)
+        B = torch.tensor([[5.0, 6.0], [7.0, 8.0]], device=self.device, dtype=dtype)
+        C = torch.empty(N, N, device=self.device, dtype=dtype)
         return {
             "A": A,
             "B": B,
@@ -48,9 +49,9 @@ class Challenge(ChallengeBase):
         # basic_2x2
         test_cases.append(
             {
-                "A": torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="cuda", dtype=dtype),
-                "B": torch.tensor([[5.0, 6.0], [7.0, 8.0]], device="cuda", dtype=dtype),
-                "C": torch.zeros((2, 2), device="cuda", dtype=dtype),
+                "A": torch.tensor([[1.0, 2.0], [3.0, 4.0]], device=self.device, dtype=dtype),
+                "B": torch.tensor([[5.0, 6.0], [7.0, 8.0]], device=self.device, dtype=dtype),
+                "C": torch.zeros((2, 2), device=self.device, dtype=dtype),
                 "N": 2,
             }
         )
@@ -58,9 +59,9 @@ class Challenge(ChallengeBase):
         # all_zeros_4x4
         test_cases.append(
             {
-                "A": torch.zeros((4, 4), device="cuda", dtype=dtype),
-                "B": torch.zeros((4, 4), device="cuda", dtype=dtype),
-                "C": torch.zeros((4, 4), device="cuda", dtype=dtype),
+                "A": torch.zeros((4, 4), device=self.device, dtype=dtype),
+                "B": torch.zeros((4, 4), device=self.device, dtype=dtype),
+                "C": torch.zeros((4, 4), device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
@@ -69,12 +70,16 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "A": torch.tensor(
-                    [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], device="cuda", dtype=dtype
+                    [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+                    device=self.device,
+                    dtype=dtype,
                 ),
                 "B": torch.tensor(
-                    [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], device="cuda", dtype=dtype
+                    [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+                    device=self.device,
+                    dtype=dtype,
                 ),
-                "C": torch.zeros((3, 3), device="cuda", dtype=dtype),
+                "C": torch.zeros((3, 3), device=self.device, dtype=dtype),
                 "N": 3,
             }
         )
@@ -82,9 +87,9 @@ class Challenge(ChallengeBase):
         # negative_values_2x2
         test_cases.append(
             {
-                "A": torch.tensor([[-1.0, -2.0], [-3.0, -4.0]], device="cuda", dtype=dtype),
-                "B": torch.tensor([[-5.0, -6.0], [-7.0, -8.0]], device="cuda", dtype=dtype),
-                "C": torch.zeros((2, 2), device="cuda", dtype=dtype),
+                "A": torch.tensor([[-1.0, -2.0], [-3.0, -4.0]], device=self.device, dtype=dtype),
+                "B": torch.tensor([[-5.0, -6.0], [-7.0, -8.0]], device=self.device, dtype=dtype),
+                "C": torch.zeros((2, 2), device=self.device, dtype=dtype),
                 "N": 2,
             }
         )
@@ -92,9 +97,9 @@ class Challenge(ChallengeBase):
         # mixed_positive_negative_2x2
         test_cases.append(
             {
-                "A": torch.tensor([[1.0, -2.0], [-3.0, 4.0]], device="cuda", dtype=dtype),
-                "B": torch.tensor([[-1.0, 2.0], [3.0, -4.0]], device="cuda", dtype=dtype),
-                "C": torch.zeros((2, 2), device="cuda", dtype=dtype),
+                "A": torch.tensor([[1.0, -2.0], [-3.0, 4.0]], device=self.device, dtype=dtype),
+                "B": torch.tensor([[-1.0, 2.0], [3.0, -4.0]], device=self.device, dtype=dtype),
+                "C": torch.zeros((2, 2), device=self.device, dtype=dtype),
                 "N": 2,
             }
         )
@@ -102,9 +107,9 @@ class Challenge(ChallengeBase):
         # single_element_1x1
         test_cases.append(
             {
-                "A": torch.tensor([[42.0]], device="cuda", dtype=dtype),
-                "B": torch.tensor([[8.0]], device="cuda", dtype=dtype),
-                "C": torch.zeros((1, 1), device="cuda", dtype=dtype),
+                "A": torch.tensor([[42.0]], device=self.device, dtype=dtype),
+                "B": torch.tensor([[8.0]], device=self.device, dtype=dtype),
+                "C": torch.zeros((1, 1), device=self.device, dtype=dtype),
                 "N": 1,
             }
         )
@@ -112,9 +117,9 @@ class Challenge(ChallengeBase):
         # large_N_16x16
         test_cases.append(
             {
-                "A": torch.empty((16, 16), device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-                "B": torch.empty((16, 16), device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-                "C": torch.zeros((16, 16), device="cuda", dtype=dtype),
+                "A": torch.empty((16, 16), device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
+                "B": torch.empty((16, 16), device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
+                "C": torch.zeros((16, 16), device=self.device, dtype=dtype),
                 "N": 16,
             }
         )
@@ -123,12 +128,16 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "A": torch.tensor(
-                    [[0.000001, 0.0000001], [0.00000001, 0.000000001]], device="cuda", dtype=dtype
+                    [[0.000001, 0.0000001], [0.00000001, 0.000000001]],
+                    device=self.device,
+                    dtype=dtype,
                 ),
                 "B": torch.tensor(
-                    [[0.000001, 0.0000001], [0.00000001, 0.000000001]], device="cuda", dtype=dtype
+                    [[0.000001, 0.0000001], [0.00000001, 0.000000001]],
+                    device=self.device,
+                    dtype=dtype,
                 ),
-                "C": torch.zeros((2, 2), device="cuda", dtype=dtype),
+                "C": torch.zeros((2, 2), device=self.device, dtype=dtype),
                 "N": 2,
             }
         )
@@ -137,12 +146,16 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "A": torch.tensor(
-                    [[1000000.0, 10000000.0], [-1000000.0, -10000000.0]], device="cuda", dtype=dtype
+                    [[1000000.0, 10000000.0], [-1000000.0, -10000000.0]],
+                    device=self.device,
+                    dtype=dtype,
                 ),
                 "B": torch.tensor(
-                    [[1000000.0, -10000000.0], [-1000000.0, 10000000.0]], device="cuda", dtype=dtype
+                    [[1000000.0, -10000000.0], [-1000000.0, 10000000.0]],
+                    device=self.device,
+                    dtype=dtype,
                 ),
-                "C": torch.zeros((2, 2), device="cuda", dtype=dtype),
+                "C": torch.zeros((2, 2), device=self.device, dtype=dtype),
                 "N": 2,
             }
         )
@@ -150,9 +163,9 @@ class Challenge(ChallengeBase):
         # non_power_of_two_size_7x7
         test_cases.append(
             {
-                "A": torch.empty((7, 7), device="cuda", dtype=dtype).uniform_(-5.0, 5.0),
-                "B": torch.empty((7, 7), device="cuda", dtype=dtype).uniform_(-5.0, 5.0),
-                "C": torch.zeros((7, 7), device="cuda", dtype=dtype),
+                "A": torch.empty((7, 7), device=self.device, dtype=dtype).uniform_(-5.0, 5.0),
+                "B": torch.empty((7, 7), device=self.device, dtype=dtype).uniform_(-5.0, 5.0),
+                "C": torch.zeros((7, 7), device=self.device, dtype=dtype),
                 "N": 7,
             }
         )
@@ -160,9 +173,9 @@ class Challenge(ChallengeBase):
         # medium_size_32x32
         test_cases.append(
             {
-                "A": torch.empty((32, 32), device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
-                "B": torch.empty((32, 32), device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
-                "C": torch.zeros((32, 32), device="cuda", dtype=dtype),
+                "A": torch.empty((32, 32), device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
+                "B": torch.empty((32, 32), device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
+                "C": torch.zeros((32, 32), device=self.device, dtype=dtype),
                 "N": 32,
             }
         )
@@ -173,8 +186,8 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 4096
         return {
-            "A": torch.empty(N, N, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0),
-            "B": torch.empty(N, N, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0),
-            "C": torch.zeros(N, N, device="cuda", dtype=dtype),
+            "A": torch.empty(N, N, device=self.device, dtype=dtype).uniform_(-1000.0, 1000.0),
+            "B": torch.empty(N, N, device=self.device, dtype=dtype).uniform_(-1000.0, 1000.0),
+            "C": torch.zeros(N, N, device=self.device, dtype=dtype),
             "N": N,
         }

--- a/challenges/easy/9_1d_convolution/challenge.py
+++ b/challenges/easy/9_1d_convolution/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="1D Convolution", atol=1e-04, rtol=1e-04, num_gpus=1, access_tier="free"
-        )
+    name = "1D Convolution"
+    atol = 0.0001
+    rtol = 0.0001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -43,9 +44,9 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        input_tensor = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda", dtype=dtype)
-        kernel_tensor = torch.tensor([1.0, 0.0, -1.0], device="cuda", dtype=dtype)
-        output_tensor = torch.empty(3, device="cuda", dtype=dtype)
+        input_tensor = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device=self.device, dtype=dtype)
+        kernel_tensor = torch.tensor([1.0, 0.0, -1.0], device=self.device, dtype=dtype)
+        output_tensor = torch.empty(3, device=self.device, dtype=dtype)
         return {
             "input": input_tensor,
             "kernel": kernel_tensor,
@@ -72,9 +73,9 @@ class Challenge(ChallengeBase):
             output_size = input_size - kernel_size + 1
             test_cases.append(
                 {
-                    "input": torch.tensor(input_vals, device="cuda", dtype=dtype),
-                    "kernel": torch.tensor(kernel_vals, device="cuda", dtype=dtype),
-                    "output": torch.empty(output_size, device="cuda", dtype=dtype),
+                    "input": torch.tensor(input_vals, device=self.device, dtype=dtype),
+                    "kernel": torch.tensor(kernel_vals, device=self.device, dtype=dtype),
+                    "output": torch.empty(output_size, device=self.device, dtype=dtype),
                     "input_size": input_size,
                     "kernel_size": kernel_size,
                 }
@@ -91,13 +92,13 @@ class Challenge(ChallengeBase):
             output_size = input_size - kernel_size + 1
             test_cases.append(
                 {
-                    "input": torch.empty(input_size, device="cuda", dtype=dtype).uniform_(
+                    "input": torch.empty(input_size, device=self.device, dtype=dtype).uniform_(
                         -10.0, 10.0
                     ),
-                    "kernel": torch.empty(kernel_size, device="cuda", dtype=dtype).uniform_(
+                    "kernel": torch.empty(kernel_size, device=self.device, dtype=dtype).uniform_(
                         -1.0, 1.0
                     ),
-                    "output": torch.empty(output_size, device="cuda", dtype=dtype),
+                    "output": torch.empty(output_size, device=self.device, dtype=dtype),
                     "input_size": input_size,
                     "kernel_size": kernel_size,
                 }
@@ -112,13 +113,13 @@ class Challenge(ChallengeBase):
             output_size = input_size - kernel_size + 1
             test_cases.append(
                 {
-                    "input": torch.empty(input_size, device="cuda", dtype=dtype).uniform_(
+                    "input": torch.empty(input_size, device=self.device, dtype=dtype).uniform_(
                         -1.0, 1.0
                     ),
-                    "kernel": torch.empty(kernel_size, device="cuda", dtype=dtype).uniform_(
+                    "kernel": torch.empty(kernel_size, device=self.device, dtype=dtype).uniform_(
                         -0.1, 0.1
                     ),
-                    "output": torch.empty(output_size, device="cuda", dtype=dtype),
+                    "output": torch.empty(output_size, device=self.device, dtype=dtype),
                     "input_size": input_size,
                     "kernel_size": kernel_size,
                 }
@@ -131,9 +132,9 @@ class Challenge(ChallengeBase):
         input_size, kernel_size = 1500000, 2047  # Large convolution for performance testing
         output_size = input_size - kernel_size + 1
         return {
-            "input": torch.empty(input_size, device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-            "kernel": torch.empty(kernel_size, device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-            "output": torch.empty(output_size, device="cuda", dtype=dtype),
+            "input": torch.empty(input_size, device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+            "kernel": torch.empty(kernel_size, device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+            "output": torch.empty(output_size, device=self.device, dtype=dtype),
             "input_size": input_size,
             "kernel_size": kernel_size,
         }

--- a/challenges/hard/12_multi_head_attention/challenge.py
+++ b/challenges/hard/12_multi_head_attention/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Multi-Head Attention", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Multi-Head Attention"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -52,10 +53,16 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        Q = torch.tensor([[1.0, 0.0, 2.0, 3.0], [4.0, 5.0, 6.0, 7.0]], device="cuda", dtype=dtype)
-        K = torch.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device="cuda", dtype=dtype)
-        V = torch.tensor([[0.5, 1.0, 1.5, 2.0], [2.5, 3.0, 3.5, 4.0]], device="cuda", dtype=dtype)
-        output = torch.empty(2, 4, device="cuda", dtype=dtype)
+        Q = torch.tensor(
+            [[1.0, 0.0, 2.0, 3.0], [4.0, 5.0, 6.0, 7.0]], device=self.device, dtype=dtype
+        )
+        K = torch.tensor(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device=self.device, dtype=dtype
+        )
+        V = torch.tensor(
+            [[0.5, 1.0, 1.5, 2.0], [2.5, 3.0, 3.5, 4.0]], device=self.device, dtype=dtype
+        )
+        output = torch.empty(2, 4, device=self.device, dtype=dtype)
         return {
             "Q": Q,
             "K": K,
@@ -70,28 +77,34 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         test_cases = []
         # basic_example
-        Q = torch.tensor([[1.0, 0.0, 2.0, 3.0], [4.0, 5.0, 6.0, 7.0]], device="cuda", dtype=dtype)
-        K = torch.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device="cuda", dtype=dtype)
-        V = torch.tensor([[0.5, 1.0, 1.5, 2.0], [2.5, 3.0, 3.5, 4.0]], device="cuda", dtype=dtype)
-        output = torch.empty(2, 4, device="cuda", dtype=dtype)
+        Q = torch.tensor(
+            [[1.0, 0.0, 2.0, 3.0], [4.0, 5.0, 6.0, 7.0]], device=self.device, dtype=dtype
+        )
+        K = torch.tensor(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device=self.device, dtype=dtype
+        )
+        V = torch.tensor(
+            [[0.5, 1.0, 1.5, 2.0], [2.5, 3.0, 3.5, 4.0]], device=self.device, dtype=dtype
+        )
+        output = torch.empty(2, 4, device=self.device, dtype=dtype)
         test_cases.append({"Q": Q, "K": K, "V": V, "output": output, "N": 2, "d_model": 4, "h": 2})
         # single_head
-        Q = torch.tensor([[1.0, 1.0], [2.0, 2.0]], device="cuda", dtype=dtype)
-        K = torch.tensor([[1.0, 1.0], [1.0, 1.0]], device="cuda", dtype=dtype)
-        V = torch.tensor([[2.0, 3.0], [4.0, 5.0]], device="cuda", dtype=dtype)
-        output = torch.empty(2, 2, device="cuda", dtype=dtype)
+        Q = torch.tensor([[1.0, 1.0], [2.0, 2.0]], device=self.device, dtype=dtype)
+        K = torch.tensor([[1.0, 1.0], [1.0, 1.0]], device=self.device, dtype=dtype)
+        V = torch.tensor([[2.0, 3.0], [4.0, 5.0]], device=self.device, dtype=dtype)
+        output = torch.empty(2, 2, device=self.device, dtype=dtype)
         test_cases.append({"Q": Q, "K": K, "V": V, "output": output, "N": 2, "d_model": 2, "h": 1})
         # four_heads (random)
-        Q = torch.empty(4, 4, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        K = torch.empty(4, 4, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        V = torch.empty(4, 4, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        output = torch.empty(4, 4, device="cuda", dtype=dtype)
+        Q = torch.empty(4, 4, device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        K = torch.empty(4, 4, device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        V = torch.empty(4, 4, device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        output = torch.empty(4, 4, device=self.device, dtype=dtype)
         test_cases.append({"Q": Q, "K": K, "V": V, "output": output, "N": 4, "d_model": 4, "h": 4})
         # medium_size (random)
-        Q = torch.empty(32, 32, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        K = torch.empty(32, 32, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        V = torch.empty(32, 32, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        output = torch.empty(32, 32, device="cuda", dtype=dtype)
+        Q = torch.empty(32, 32, device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        K = torch.empty(32, 32, device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        V = torch.empty(32, 32, device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        output = torch.empty(32, 32, device=self.device, dtype=dtype)
         test_cases.append(
             {"Q": Q, "K": K, "V": V, "output": output, "N": 32, "d_model": 32, "h": 8}
         )
@@ -99,10 +112,10 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        Q = torch.empty(1024, 1024, device="cuda", dtype=dtype).uniform_(-10.0, 10.0)
-        K = torch.empty(1024, 1024, device="cuda", dtype=dtype).uniform_(-10.0, 10.0)
-        V = torch.empty(1024, 1024, device="cuda", dtype=dtype).uniform_(-10.0, 10.0)
-        output = torch.zeros(1024, 1024, device="cuda", dtype=dtype)
+        Q = torch.empty(1024, 1024, device=self.device, dtype=dtype).uniform_(-10.0, 10.0)
+        K = torch.empty(1024, 1024, device=self.device, dtype=dtype).uniform_(-10.0, 10.0)
+        V = torch.empty(1024, 1024, device=self.device, dtype=dtype).uniform_(-10.0, 10.0)
+        output = torch.zeros(1024, 1024, device=self.device, dtype=dtype)
         return {
             "Q": Q,
             "K": K,

--- a/challenges/hard/14_multi_agent_sim/challenge.py
+++ b/challenges/hard/14_multi_agent_sim/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Multi-Agent Simulation", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Multi-Agent Simulation"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, agents: torch.Tensor, agents_next: torch.Tensor, N: int):
         assert agents.shape == (4 * N,)
@@ -48,8 +49,10 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 2
-        agents = torch.tensor([0.0, 0.0, 1.0, 0.0, 5.0, 0.0, 0.0, 1.0], device="cuda", dtype=dtype)
-        agents_next = torch.empty(4 * N, device="cuda", dtype=dtype)
+        agents = torch.tensor(
+            [0.0, 0.0, 1.0, 0.0, 5.0, 0.0, 0.0, 1.0], device=self.device, dtype=dtype
+        )
+        agents_next = torch.empty(4 * N, device=self.device, dtype=dtype)
         return {
             "agents": agents,
             "agents_next": agents_next,
@@ -60,41 +63,45 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         test_cases = []
         # basic_example
-        agents = torch.tensor([0.0, 0.0, 1.0, 0.0, 3.0, 4.0, 0.0, -1.0], device="cuda", dtype=dtype)
-        agents_next = torch.empty(8, device="cuda", dtype=dtype)
+        agents = torch.tensor(
+            [0.0, 0.0, 1.0, 0.0, 3.0, 4.0, 0.0, -1.0], device=self.device, dtype=dtype
+        )
+        agents_next = torch.empty(8, device=self.device, dtype=dtype)
         test_cases.append({"agents": agents, "agents_next": agents_next, "N": 2})
         # single_agent
-        agents = torch.tensor([10.0, 15.0, 1.0, -1.0], device="cuda", dtype=dtype)
-        agents_next = torch.empty(4, device="cuda", dtype=dtype)
+        agents = torch.tensor([10.0, 15.0, 1.0, -1.0], device=self.device, dtype=dtype)
+        agents_next = torch.empty(4, device=self.device, dtype=dtype)
         test_cases.append({"agents": agents, "agents_next": agents_next, "N": 1})
         # two_agents_interacting
-        agents = torch.tensor([0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0], device="cuda", dtype=dtype)
-        agents_next = torch.empty(8, device="cuda", dtype=dtype)
+        agents = torch.tensor(
+            [0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0], device=self.device, dtype=dtype
+        )
+        agents_next = torch.empty(8, device=self.device, dtype=dtype)
         test_cases.append({"agents": agents, "agents_next": agents_next, "N": 2})
         # four_agents
         agents = torch.tensor(
             [0.0, 0.0, 1.0, 0.0, 2.0, 2.0, 0.0, 1.0, 4.0, 4.0, -1.0, 0.0, 6.0, 6.0, 0.0, -1.0],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        agents_next = torch.empty(16, device="cuda", dtype=dtype)
+        agents_next = torch.empty(16, device=self.device, dtype=dtype)
         test_cases.append({"agents": agents, "agents_next": agents_next, "N": 4})
         # boundary_distance
         agents = torch.tensor(
-            [0.0, 0.0, 1.0, 1.0, 3.0, 4.0, -1.0, -1.0], device="cuda", dtype=dtype
+            [0.0, 0.0, 1.0, 1.0, 3.0, 4.0, -1.0, -1.0], device=self.device, dtype=dtype
         )
-        agents_next = torch.empty(8, device="cuda", dtype=dtype)
+        agents_next = torch.empty(8, device=self.device, dtype=dtype)
         test_cases.append({"agents": agents, "agents_next": agents_next, "N": 2})
         # medium_simulation (random)
-        agents = torch.empty(4096, device="cuda", dtype=dtype).uniform_(-100.0, 100.0)
-        agents_next = torch.empty(4096, device="cuda", dtype=dtype)
+        agents = torch.empty(4096, device=self.device, dtype=dtype).uniform_(-100.0, 100.0)
+        agents_next = torch.empty(4096, device=self.device, dtype=dtype)
         test_cases.append({"agents": agents, "agents_next": agents_next, "N": 1024})
         return test_cases
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        agents = torch.empty(40000, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0)
-        agents_next = torch.empty(40000, device="cuda", dtype=dtype)
+        agents = torch.empty(40000, device=self.device, dtype=dtype).uniform_(-1000.0, 1000.0)
+        agents_next = torch.empty(40000, device=self.device, dtype=dtype)
         return {
             "agents": agents,
             "agents_next": agents_next,

--- a/challenges/hard/15_sorting/challenge.py
+++ b/challenges/hard/15_sorting/challenge.py
@@ -6,8 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(name="Sorting", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free")
+    name = "Sorting"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, data: torch.Tensor, N: int):
         assert data.shape == (N,)
@@ -21,7 +24,7 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        data = torch.tensor([5.0, 2.0, 8.0, 1.0, 9.0, 4.0], device="cuda", dtype=dtype)
+        data = torch.tensor([5.0, 2.0, 8.0, 1.0, 9.0, 4.0], device=self.device, dtype=dtype)
         return {
             "data": data,
             "N": 6,
@@ -32,34 +35,42 @@ class Challenge(ChallengeBase):
         tests = []
         # already_sorted
         tests.append(
-            {"data": torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda", dtype=dtype), "N": 5}
+            {
+                "data": torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device=self.device, dtype=dtype),
+                "N": 5,
+            }
         )
         # reverse_sorted
         tests.append(
-            {"data": torch.tensor([5.0, 4.0, 3.0, 2.0, 1.0], device="cuda", dtype=dtype), "N": 5}
+            {
+                "data": torch.tensor([5.0, 4.0, 3.0, 2.0, 1.0], device=self.device, dtype=dtype),
+                "N": 5,
+            }
         )
         # all_same
-        tests.append({"data": torch.tensor([5.0] * 10, device="cuda", dtype=dtype), "N": 10})
+        tests.append({"data": torch.tensor([5.0] * 10, device=self.device, dtype=dtype), "N": 10})
         # single_element
-        tests.append({"data": torch.tensor([7.0], device="cuda", dtype=dtype), "N": 1})
+        tests.append({"data": torch.tensor([7.0], device=self.device, dtype=dtype), "N": 1})
         # power_of_two
         tests.append(
             {
-                "data": torch.empty(1024, device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
+                "data": torch.empty(1024, device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
                 "N": 1024,
             }
         )
         # non_power_of_two
         tests.append(
             {
-                "data": torch.empty(1000, device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
+                "data": torch.empty(1000, device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
                 "N": 1000,
             }
         )
         # large_array
         tests.append(
             {
-                "data": torch.empty(32768, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0),
+                "data": torch.empty(32768, device=self.device, dtype=dtype).uniform_(
+                    -1000.0, 1000.0
+                ),
                 "N": 32768,
             }
         )
@@ -68,7 +79,7 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 1000000
-        data = torch.empty(N, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0)
+        data = torch.empty(N, device=self.device, dtype=dtype).uniform_(-1000.0, 1000.0)
         return {
             "data": data,
             "N": N,

--- a/challenges/hard/20_kmeans_clustering/challenge.py
+++ b/challenges/hard/20_kmeans_clustering/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="K-Means Clustering", atol=1e-04, rtol=1e-04, num_gpus=1, access_tier="free"
-        )
+    name = "K-Means Clustering"
+    atol = 0.0001
+    rtol = 0.0001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -61,13 +62,13 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         sample_size, k, max_iterations = 4, 2, 10
-        data_x = torch.tensor([1.0, 2.0, 8.0, 9.0], device="cuda", dtype=dtype)
-        data_y = torch.tensor([1.0, 2.0, 8.0, 9.0], device="cuda", dtype=dtype)
-        labels = torch.empty(sample_size, device="cuda", dtype=torch.int32)
-        initial_centroid_x = torch.tensor([1.0, 8.0], device="cuda", dtype=dtype)
-        initial_centroid_y = torch.tensor([1.0, 8.0], device="cuda", dtype=dtype)
-        final_centroid_x = torch.empty(k, device="cuda", dtype=dtype)
-        final_centroid_y = torch.empty(k, device="cuda", dtype=dtype)
+        data_x = torch.tensor([1.0, 2.0, 8.0, 9.0], device=self.device, dtype=dtype)
+        data_y = torch.tensor([1.0, 2.0, 8.0, 9.0], device=self.device, dtype=dtype)
+        labels = torch.empty(sample_size, device=self.device, dtype=torch.int32)
+        initial_centroid_x = torch.tensor([1.0, 8.0], device=self.device, dtype=dtype)
+        initial_centroid_y = torch.tensor([1.0, 8.0], device=self.device, dtype=dtype)
+        final_centroid_x = torch.empty(k, device=self.device, dtype=dtype)
+        final_centroid_y = torch.empty(k, device=self.device, dtype=dtype)
         return {
             "data_x": data_x,
             "data_y": data_y,
@@ -87,19 +88,19 @@ class Challenge(ChallengeBase):
         # basic_clustering
         data_x = torch.tensor(
             [1.0, 1.5, 1.2, 1.3, 1.1, 5.0, 5.2, 5.1, 5.3, 5.4, 10.1, 10.2, 10.0, 10.3, 10.5],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
         data_y = torch.tensor(
             [1.0, 1.5, 1.2, 1.3, 1.1, 5.0, 5.2, 5.1, 5.3, 5.4, 10.1, 10.2, 10.0, 10.3, 10.5],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        labels = torch.empty(15, device="cuda", dtype=torch.int32)
-        initial_centroid_x = torch.tensor([3.4, 7.1, 8.5], device="cuda", dtype=dtype)
-        initial_centroid_y = torch.tensor([3.4, 7.1, 8.5], device="cuda", dtype=dtype)
-        final_centroid_x = torch.empty(3, device="cuda", dtype=dtype)
-        final_centroid_y = torch.empty(3, device="cuda", dtype=dtype)
+        labels = torch.empty(15, device=self.device, dtype=torch.int32)
+        initial_centroid_x = torch.tensor([3.4, 7.1, 8.5], device=self.device, dtype=dtype)
+        initial_centroid_y = torch.tensor([3.4, 7.1, 8.5], device=self.device, dtype=dtype)
+        final_centroid_x = torch.empty(3, device=self.device, dtype=dtype)
+        final_centroid_y = torch.empty(3, device=self.device, dtype=dtype)
         test_cases.append(
             {
                 "data_x": data_x,
@@ -116,16 +117,16 @@ class Challenge(ChallengeBase):
         )
         # single_cluster
         data_x = torch.tensor(
-            [1.0, 1.2, 1.1, 1.3, 1.5, 1.4, 1.6, 1.2, 1.3, 1.1], device="cuda", dtype=dtype
+            [1.0, 1.2, 1.1, 1.3, 1.5, 1.4, 1.6, 1.2, 1.3, 1.1], device=self.device, dtype=dtype
         )
         data_y = torch.tensor(
-            [1.0, 1.2, 1.1, 1.3, 1.5, 1.4, 1.6, 1.2, 1.3, 1.1], device="cuda", dtype=dtype
+            [1.0, 1.2, 1.1, 1.3, 1.5, 1.4, 1.6, 1.2, 1.3, 1.1], device=self.device, dtype=dtype
         )
-        labels = torch.empty(10, device="cuda", dtype=torch.int32)
-        initial_centroid_x = torch.tensor([1.0, 5.0, 10.0], device="cuda", dtype=dtype)
-        initial_centroid_y = torch.tensor([1.0, 5.0, 10.0], device="cuda", dtype=dtype)
-        final_centroid_x = torch.empty(3, device="cuda", dtype=dtype)
-        final_centroid_y = torch.empty(3, device="cuda", dtype=dtype)
+        labels = torch.empty(10, device=self.device, dtype=torch.int32)
+        initial_centroid_x = torch.tensor([1.0, 5.0, 10.0], device=self.device, dtype=dtype)
+        initial_centroid_y = torch.tensor([1.0, 5.0, 10.0], device=self.device, dtype=dtype)
+        final_centroid_x = torch.empty(3, device=self.device, dtype=dtype)
+        final_centroid_y = torch.empty(3, device=self.device, dtype=dtype)
         test_cases.append(
             {
                 "data_x": data_x,
@@ -164,7 +165,7 @@ class Challenge(ChallengeBase):
                 10.7,
                 10.3,
             ],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
         data_y = torch.tensor(
@@ -190,14 +191,14 @@ class Challenge(ChallengeBase):
                 10.7,
                 10.3,
             ],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        labels = torch.empty(20, device="cuda", dtype=torch.int32)
-        initial_centroid_x = torch.tensor([1.5, 5.0, 10.5], device="cuda", dtype=dtype)
-        initial_centroid_y = torch.tensor([1.5, 5.0, 10.5], device="cuda", dtype=dtype)
-        final_centroid_x = torch.empty(3, device="cuda", dtype=dtype)
-        final_centroid_y = torch.empty(3, device="cuda", dtype=dtype)
+        labels = torch.empty(20, device=self.device, dtype=torch.int32)
+        initial_centroid_x = torch.tensor([1.5, 5.0, 10.5], device=self.device, dtype=dtype)
+        initial_centroid_y = torch.tensor([1.5, 5.0, 10.5], device=self.device, dtype=dtype)
+        final_centroid_x = torch.empty(3, device=self.device, dtype=dtype)
+        final_centroid_y = torch.empty(3, device=self.device, dtype=dtype)
         test_cases.append(
             {
                 "data_x": data_x,
@@ -215,19 +216,19 @@ class Challenge(ChallengeBase):
         # max_iterations_limit
         data_x = torch.tensor(
             [1.0, 1.5, 1.2, 1.3, 1.1, 5.0, 5.2, 5.1, 5.3, 5.4, 10.1, 10.2, 10.0, 10.3, 10.5],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
         data_y = torch.tensor(
             [1.0, 1.5, 1.2, 1.3, 1.1, 5.0, 5.2, 5.1, 5.3, 5.4, 10.1, 10.2, 10.0, 10.3, 10.5],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        labels = torch.empty(15, device="cuda", dtype=torch.int32)
-        initial_centroid_x = torch.tensor([3.4, 7.1, 8.5], device="cuda", dtype=dtype)
-        initial_centroid_y = torch.tensor([3.4, 7.1, 8.5], device="cuda", dtype=dtype)
-        final_centroid_x = torch.empty(3, device="cuda", dtype=dtype)
-        final_centroid_y = torch.empty(3, device="cuda", dtype=dtype)
+        labels = torch.empty(15, device=self.device, dtype=torch.int32)
+        initial_centroid_x = torch.tensor([3.4, 7.1, 8.5], device=self.device, dtype=dtype)
+        initial_centroid_y = torch.tensor([3.4, 7.1, 8.5], device=self.device, dtype=dtype)
+        final_centroid_x = torch.empty(3, device=self.device, dtype=dtype)
+        final_centroid_y = torch.empty(3, device=self.device, dtype=dtype)
         test_cases.append(
             {
                 "data_x": data_x,
@@ -245,17 +246,17 @@ class Challenge(ChallengeBase):
         # medium_random
         sample_size = 100
         k = 5
-        data_x = torch.empty(sample_size, device="cuda", dtype=dtype).uniform_(0.0, 100.0)
-        data_y = torch.empty(sample_size, device="cuda", dtype=dtype).uniform_(0.0, 100.0)
-        labels = torch.empty(sample_size, device="cuda", dtype=torch.int32)
+        data_x = torch.empty(sample_size, device=self.device, dtype=dtype).uniform_(0.0, 100.0)
+        data_y = torch.empty(sample_size, device=self.device, dtype=dtype).uniform_(0.0, 100.0)
+        labels = torch.empty(sample_size, device=self.device, dtype=torch.int32)
         initial_centroid_x = torch.tensor(
-            [20.0, 40.0, 60.0, 80.0, 10.0], device="cuda", dtype=dtype
+            [20.0, 40.0, 60.0, 80.0, 10.0], device=self.device, dtype=dtype
         )
         initial_centroid_y = torch.tensor(
-            [20.0, 40.0, 60.0, 80.0, 50.0], device="cuda", dtype=dtype
+            [20.0, 40.0, 60.0, 80.0, 50.0], device=self.device, dtype=dtype
         )
-        final_centroid_x = torch.empty(k, device="cuda", dtype=dtype)
-        final_centroid_y = torch.empty(k, device="cuda", dtype=dtype)
+        final_centroid_x = torch.empty(k, device=self.device, dtype=dtype)
+        final_centroid_y = torch.empty(k, device=self.device, dtype=dtype)
         test_cases.append(
             {
                 "data_x": data_x,
@@ -276,17 +277,17 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         sample_size = 10000
         k = 5
-        data_x = torch.empty(sample_size, device="cuda", dtype=dtype).uniform_(0.0, 1000.0)
-        data_y = torch.empty(sample_size, device="cuda", dtype=dtype).uniform_(0.0, 1000.0)
-        labels = torch.empty(sample_size, device="cuda", dtype=torch.int32)
+        data_x = torch.empty(sample_size, device=self.device, dtype=dtype).uniform_(0.0, 1000.0)
+        data_y = torch.empty(sample_size, device=self.device, dtype=dtype).uniform_(0.0, 1000.0)
+        labels = torch.empty(sample_size, device=self.device, dtype=torch.int32)
         initial_centroid_x = torch.tensor(
-            [100.0, 200.0, 300.0, 400.0, 500.0], device="cuda", dtype=dtype
+            [100.0, 200.0, 300.0, 400.0, 500.0], device=self.device, dtype=dtype
         )
         initial_centroid_y = torch.tensor(
-            [100.0, 200.0, 300.0, 400.0, 500.0], device="cuda", dtype=dtype
+            [100.0, 200.0, 300.0, 400.0, 500.0], device=self.device, dtype=dtype
         )
-        final_centroid_x = torch.empty(k, device="cuda", dtype=dtype)
-        final_centroid_y = torch.empty(k, device="cuda", dtype=dtype)
+        final_centroid_x = torch.empty(k, device=self.device, dtype=dtype)
+        final_centroid_y = torch.empty(k, device=self.device, dtype=dtype)
         return {
             "data_x": data_x,
             "data_y": data_y,

--- a/challenges/hard/36_radix_sort/challenge.py
+++ b/challenges/hard/36_radix_sort/challenge.py
@@ -6,8 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(name="Radix Sort", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free")
+    name = "Radix Sort"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int):
 
@@ -31,8 +34,10 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.uint32
         N = 8
-        input_data = torch.tensor([170, 45, 75, 90, 2, 802, 24, 66], device="cuda", dtype=dtype)
-        output_data = torch.zeros(N, device="cuda", dtype=dtype)
+        input_data = torch.tensor(
+            [170, 45, 75, 90, 2, 802, 24, 66], device=self.device, dtype=dtype
+        )
+        output_data = torch.zeros(N, device=self.device, dtype=dtype)
         return {
             "input": input_data,
             "output": output_data,
@@ -47,9 +52,9 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "input": torch.tensor(
-                    [170, 45, 75, 90, 2, 802, 24, 66], device="cuda", dtype=dtype
+                    [170, 45, 75, 90, 2, 802, 24, 66], device=self.device, dtype=dtype
                 ),
-                "output": torch.zeros(8, device="cuda", dtype=dtype),
+                "output": torch.zeros(8, device=self.device, dtype=dtype),
                 "N": 8,
             }
         )
@@ -57,8 +62,8 @@ class Challenge(ChallengeBase):
         # Test case 2: duplicate numbers
         test_cases.append(
             {
-                "input": torch.tensor([1, 4, 1, 3, 555, 1000, 2], device="cuda", dtype=dtype),
-                "output": torch.zeros(7, device="cuda", dtype=dtype),
+                "input": torch.tensor([1, 4, 1, 3, 555, 1000, 2], device=self.device, dtype=dtype),
+                "output": torch.zeros(7, device=self.device, dtype=dtype),
                 "N": 7,
             }
         )
@@ -66,8 +71,8 @@ class Challenge(ChallengeBase):
         # Test case 3: single element
         test_cases.append(
             {
-                "input": torch.tensor([42], device="cuda", dtype=dtype),
-                "output": torch.zeros(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([42], device=self.device, dtype=dtype),
+                "output": torch.zeros(1, device=self.device, dtype=dtype),
                 "N": 1,
             }
         )
@@ -75,8 +80,8 @@ class Challenge(ChallengeBase):
         # Test case 4: already sorted
         test_cases.append(
             {
-                "input": torch.tensor([1, 2, 3, 4, 5, 6], device="cuda", dtype=dtype),
-                "output": torch.zeros(6, device="cuda", dtype=dtype),
+                "input": torch.tensor([1, 2, 3, 4, 5, 6], device=self.device, dtype=dtype),
+                "output": torch.zeros(6, device=self.device, dtype=dtype),
                 "N": 6,
             }
         )
@@ -84,8 +89,8 @@ class Challenge(ChallengeBase):
         # Test case 5: reverse sorted
         test_cases.append(
             {
-                "input": torch.tensor([6, 5, 4, 3, 2, 1], device="cuda", dtype=dtype),
-                "output": torch.zeros(6, device="cuda", dtype=dtype),
+                "input": torch.tensor([6, 5, 4, 3, 2, 1], device=self.device, dtype=dtype),
+                "output": torch.zeros(6, device=self.device, dtype=dtype),
                 "N": 6,
             }
         )
@@ -95,10 +100,10 @@ class Challenge(ChallengeBase):
             {
                 "input": torch.tensor(
                     [4294967295, 1000000000, 500000000, 2000000000, 100000000],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "output": torch.zeros(5, device="cuda", dtype=dtype),
+                "output": torch.zeros(5, device=self.device, dtype=dtype),
                 "N": 5,
             }
         )
@@ -106,8 +111,8 @@ class Challenge(ChallengeBase):
         # Test case 7: medium random
         test_cases.append(
             {
-                "input": torch.randint(0, 1000001, (1024,), device="cuda", dtype=dtype),
-                "output": torch.zeros(1024, device="cuda", dtype=dtype),
+                "input": torch.randint(0, 1000001, (1024,), device=self.device, dtype=dtype),
+                "output": torch.zeros(1024, device=self.device, dtype=dtype),
                 "N": 1024,
             }
         )
@@ -115,8 +120,8 @@ class Challenge(ChallengeBase):
         # Test case 8: large random
         test_cases.append(
             {
-                "input": torch.randint(0, 4294967296, (10000,), device="cuda", dtype=dtype),
-                "output": torch.zeros(10000, device="cuda", dtype=dtype),
+                "input": torch.randint(0, 4294967296, (10000,), device=self.device, dtype=dtype),
+                "output": torch.zeros(10000, device=self.device, dtype=dtype),
                 "N": 10000,
             }
         )
@@ -127,7 +132,7 @@ class Challenge(ChallengeBase):
         dtype = torch.uint32
         N = 50000000
         return {
-            "input": torch.randint(0, 4294967296, (N,), device="cuda", dtype=dtype),
-            "output": torch.zeros(N, device="cuda", dtype=dtype),
+            "input": torch.randint(0, 4294967296, (N,), device=self.device, dtype=dtype),
+            "output": torch.zeros(N, device=self.device, dtype=dtype),
             "N": N,
         }

--- a/challenges/hard/39_Fast_Fourier_transform/challenge.py
+++ b/challenges/hard/39_Fast_Fourier_transform/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Fast Fourier Transform", atol=1e-3, rtol=1e-3, num_gpus=1, access_tier="free"
-        )
+    name = "Fast Fourier Transform"
+    atol = 0.001
+    rtol = 0.001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, signal: torch.Tensor, spectrum: torch.Tensor, N: int):
         """
@@ -50,8 +51,10 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 4
         # Impulse signal δ[n] = 1 when n=0 else 0 (expected flat spectrum)
-        signal = torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], device="cuda", dtype=dtype)
-        spectrum = torch.empty(2 * N, device="cuda", dtype=dtype)
+        signal = torch.tensor(
+            [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], device=self.device, dtype=dtype
+        )
+        spectrum = torch.empty(2 * N, device=self.device, dtype=dtype)
         return {"signal": signal, "spectrum": spectrum, "N": N}
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
@@ -60,14 +63,14 @@ class Challenge(ChallengeBase):
 
         # 1. Constant signal  (all ones) – DC spike only
         N = 8
-        const_sig = torch.ones(2 * N, device="cuda", dtype=dtype)
+        const_sig = torch.ones(2 * N, device=self.device, dtype=dtype)
         const_spec = torch.empty_like(const_sig)
         cases.append({"signal": const_sig, "spectrum": const_spec, "N": N})
 
         # 2. Single-frequency sinusoid  (real: cos, imag: sin)
         N = 16
         k = 3  # frequency bin
-        n = torch.arange(N, device="cuda", dtype=dtype)
+        n = torch.arange(N, device=self.device, dtype=dtype)
         real = torch.cos(2.0 * torch.pi * k * n / N)
         imag = torch.sin(2.0 * torch.pi * k * n / N)
         sinusoid = torch.stack((real, imag), dim=1).contiguous().view(-1)
@@ -76,19 +79,19 @@ class Challenge(ChallengeBase):
 
         # 3. Random complex signal, power-of-two length
         N = 256
-        rnd = torch.empty(2 * N, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
+        rnd = torch.empty(2 * N, device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
         rnd_spec = torch.empty_like(rnd)
         cases.append({"signal": rnd, "spectrum": rnd_spec, "N": N})
 
         # 4. Random complex signal, non-power-of-two length
         N = 250
-        rnd_np2 = torch.empty(2 * N, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
+        rnd_np2 = torch.empty(2 * N, device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
         rnd_np2_spec = torch.empty_like(rnd_np2)
         cases.append({"signal": rnd_np2, "spectrum": rnd_np2_spec, "N": N})
 
         # 5. Medium-size signal (performance sanity)
         N = 4096
-        med = torch.empty(2 * N, device="cuda", dtype=dtype).normal_(0.0, 0.5)
+        med = torch.empty(2 * N, device=self.device, dtype=dtype).normal_(0.0, 0.5)
         med_spec = torch.empty_like(med)
         cases.append({"signal": med, "spectrum": med_spec, "N": N})
 
@@ -97,6 +100,6 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 262_144  # 256 K complex samples  (~2 MiB real/imag)
-        big_sig = torch.empty(2 * N, device="cuda", dtype=dtype).normal_(0.0, 1.0)
+        big_sig = torch.empty(2 * N, device=self.device, dtype=dtype).normal_(0.0, 1.0)
         big_spec = torch.empty_like(big_sig)
         return {"signal": big_sig, "spectrum": big_spec, "N": N}

--- a/challenges/hard/46_bfs_shortest_path/challenge.py
+++ b/challenges/hard/46_bfs_shortest_path/challenge.py
@@ -6,8 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(name="BFS Shortest Path", atol=0, rtol=0, num_gpus=1, access_tier="free")
+    name = "BFS Shortest Path"
+    atol = 0
+    rtol = 0
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -99,11 +102,11 @@ class Challenge(ChallengeBase):
         # Grid: [[0,0,0,0], [1,1,0,1], [0,0,0,0], [0,1,1,0]]
         grid_data = torch.tensor(
             [0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0],  # row 0  # row 1  # row 2  # row 3
-            device="cuda",
+            device=self.device,
             dtype=dtype_int,
         )
 
-        result_data = torch.tensor([0], device="cuda", dtype=dtype_int)
+        result_data = torch.tensor([0], device=self.device, dtype=dtype_int)
 
         return {
             "grid": grid_data,
@@ -123,8 +126,8 @@ class Challenge(ChallengeBase):
         # Test case 1: Simple path exists
         test_cases.append(
             {
-                "grid": torch.tensor([0, 0, 1, 0, 0, 0], device="cuda", dtype=dtype_int),
-                "result": torch.tensor([0], device="cuda", dtype=dtype_int),
+                "grid": torch.tensor([0, 0, 1, 0, 0, 0], device=self.device, dtype=dtype_int),
+                "result": torch.tensor([0], device=self.device, dtype=dtype_int),
                 "rows": 2,
                 "cols": 3,
                 "start_row": 0,
@@ -137,8 +140,8 @@ class Challenge(ChallengeBase):
         # Test case 2: No path (blocked)
         test_cases.append(
             {
-                "grid": torch.tensor([0, 1, 0, 1, 0], device="cuda", dtype=dtype_int),
-                "result": torch.tensor([0], device="cuda", dtype=dtype_int),
+                "grid": torch.tensor([0, 1, 0, 1, 0], device=self.device, dtype=dtype_int),
+                "result": torch.tensor([0], device=self.device, dtype=dtype_int),
                 "rows": 1,
                 "cols": 5,
                 "start_row": 0,
@@ -151,8 +154,8 @@ class Challenge(ChallengeBase):
         # Test case 3: Same start and end
         test_cases.append(
             {
-                "grid": torch.tensor([0, 1, 0, 0], device="cuda", dtype=dtype_int),
-                "result": torch.tensor([0], device="cuda", dtype=dtype_int),
+                "grid": torch.tensor([0, 1, 0, 0], device=self.device, dtype=dtype_int),
+                "result": torch.tensor([0], device=self.device, dtype=dtype_int),
                 "rows": 2,
                 "cols": 2,
                 "start_row": 0,
@@ -165,8 +168,8 @@ class Challenge(ChallengeBase):
         # Test case 4: Single cell
         test_cases.append(
             {
-                "grid": torch.tensor([0], device="cuda", dtype=dtype_int),
-                "result": torch.tensor([0], device="cuda", dtype=dtype_int),
+                "grid": torch.tensor([0], device=self.device, dtype=dtype_int),
+                "result": torch.tensor([0], device=self.device, dtype=dtype_int),
                 "rows": 1,
                 "cols": 1,
                 "start_row": 0,
@@ -177,14 +180,14 @@ class Challenge(ChallengeBase):
         )
 
         # Test case 5: Larger grid with path
-        large_grid = torch.zeros(25, device="cuda", dtype=dtype_int)  # 5x5 grid
+        large_grid = torch.zeros(25, device=self.device, dtype=dtype_int)  # 5x5 grid
         large_grid[6] = 1  # obstacle at (1,1)
         large_grid[7] = 1  # obstacle at (1,2)
         large_grid[8] = 1  # obstacle at (1,3)
         test_cases.append(
             {
                 "grid": large_grid,
-                "result": torch.tensor([0], device="cuda", dtype=dtype_int),
+                "result": torch.tensor([0], device=self.device, dtype=dtype_int),
                 "rows": 5,
                 "cols": 5,
                 "start_row": 0,
@@ -197,13 +200,13 @@ class Challenge(ChallengeBase):
         # Test case 6: Complex maze
         maze_grid = torch.tensor(
             [0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0],
-            device="cuda",
+            device=self.device,
             dtype=dtype_int,
         )
         test_cases.append(
             {
                 "grid": maze_grid,
-                "result": torch.tensor([0], device="cuda", dtype=dtype_int),
+                "result": torch.tensor([0], device=self.device, dtype=dtype_int),
                 "rows": 5,
                 "cols": 5,
                 "start_row": 0,
@@ -221,7 +224,7 @@ class Challenge(ChallengeBase):
 
         # Create a large grid with some random obstacles
         torch.manual_seed(42)
-        grid = torch.randint(0, 2, (rows * cols,), device="cuda", dtype=dtype_int)
+        grid = torch.randint(0, 2, (rows * cols,), device=self.device, dtype=dtype_int)
 
         # Ensure start and end are free
         grid[0] = 0  # start at (0,0)
@@ -232,7 +235,7 @@ class Challenge(ChallengeBase):
             if i + cols - 1 < rows * cols:
                 grid[i : i + min(cols, 10)] = 0  # Clear first 10 cells of each row
 
-        result = torch.tensor([0], device="cuda", dtype=dtype_int)
+        result = torch.tensor([0], device=self.device, dtype=dtype_int)
 
         return {
             "grid": grid,

--- a/challenges/hard/53_casual_attention/challenge.py
+++ b/challenges/hard/53_casual_attention/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Causal Self-Attention", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Causal Self-Attention"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -41,10 +42,16 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        Q = torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype)
-        K = torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype)
-        V = torch.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device="cuda", dtype=dtype)
-        output = torch.empty(2, 4, device="cuda", dtype=dtype)
+        Q = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
+        )
+        K = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
+        )
+        V = torch.tensor(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device=self.device, dtype=dtype
+        )
+        output = torch.empty(2, 4, device=self.device, dtype=dtype)
         return {"Q": Q, "K": K, "V": V, "output": output, "M": 2, "d": 4}
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
@@ -55,15 +62,15 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "Q": torch.tensor(
-                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype
+                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
                 ),
                 "K": torch.tensor(
-                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype
+                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
                 ),
                 "V": torch.tensor(
-                    [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device="cuda", dtype=dtype
+                    [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device=self.device, dtype=dtype
                 ),
-                "output": torch.empty(2, 4, device="cuda", dtype=dtype),
+                "output": torch.empty(2, 4, device=self.device, dtype=dtype),
                 "M": 2,
                 "d": 4,
             }
@@ -72,10 +79,10 @@ class Challenge(ChallengeBase):
         # zero_matrices
         tests.append(
             {
-                "Q": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "K": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "V": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "output": torch.empty(3, 5, device="cuda", dtype=dtype),
+                "Q": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "K": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "V": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "output": torch.empty(3, 5, device=self.device, dtype=dtype),
                 "M": 3,
                 "d": 5,
             }
@@ -86,20 +93,20 @@ class Challenge(ChallengeBase):
             {
                 "Q": torch.tensor(
                     [[-1.0, 2.0, -3.0], [4.0, -5.0, 6.0], [-7.0, 8.0, -9.0], [10.0, -11.0, 12.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "K": torch.tensor(
                     [[2.0, -1.0, 3.0], [-4.0, 5.0, -6.0], [7.0, -8.0, 9.0], [-10.0, 11.0, -12.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "V": torch.tensor(
                     [[1.0, 0.5, -0.5], [-1.0, 2.0, 3.0], [4.0, -2.0, 1.0], [0.0, 1.0, -1.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "output": torch.empty(4, 3, device="cuda", dtype=dtype),
+                "output": torch.empty(4, 3, device=self.device, dtype=dtype),
                 "M": 4,
                 "d": 3,
             }
@@ -108,10 +115,10 @@ class Challenge(ChallengeBase):
         # large_matrices
         tests.append(
             {
-                "Q": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "K": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "V": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "output": torch.empty(128, 32, device="cuda", dtype=dtype),
+                "Q": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "K": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "V": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "output": torch.empty(128, 32, device=self.device, dtype=dtype),
                 "M": 128,
                 "d": 32,
             }
@@ -122,8 +129,8 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         M, d = 5000, 128
-        Q = torch.empty((M, d), device="cuda", dtype=dtype).uniform_(-100, 100)
-        K = torch.empty((M, d), device="cuda", dtype=dtype).uniform_(-100, 100)
-        V = torch.empty((M, d), device="cuda", dtype=dtype).uniform_(-100, 100)
-        output = torch.empty(M, d, device="cuda", dtype=dtype)
+        Q = torch.empty((M, d), device=self.device, dtype=dtype).uniform_(-100, 100)
+        K = torch.empty((M, d), device=self.device, dtype=dtype).uniform_(-100, 100)
+        V = torch.empty((M, d), device=self.device, dtype=dtype).uniform_(-100, 100)
+        output = torch.empty(M, d, device=self.device, dtype=dtype)
         return {"Q": Q, "K": K, "V": V, "output": output, "M": M, "d": d}

--- a/challenges/hard/56_linear_attention/challenge.py
+++ b/challenges/hard/56_linear_attention/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Linear Self-Attention", atol=1e-04, rtol=1e-04, num_gpus=1, access_tier="free"
-        )
+    name = "Linear Self-Attention"
+    atol = 0.0001
+    rtol = 0.0001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -49,10 +50,16 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        Q = torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype)
-        K = torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype)
-        V = torch.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device="cuda", dtype=dtype)
-        output = torch.empty(2, 4, device="cuda", dtype=dtype)
+        Q = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
+        )
+        K = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
+        )
+        V = torch.tensor(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device=self.device, dtype=dtype
+        )
+        output = torch.empty(2, 4, device=self.device, dtype=dtype)
         return {"Q": Q, "K": K, "V": V, "output": output, "M": 2, "d": 4}
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
@@ -63,15 +70,15 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "Q": torch.tensor(
-                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype
+                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
                 ),
                 "K": torch.tensor(
-                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype
+                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
                 ),
                 "V": torch.tensor(
-                    [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device="cuda", dtype=dtype
+                    [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device=self.device, dtype=dtype
                 ),
-                "output": torch.empty(2, 4, device="cuda", dtype=dtype),
+                "output": torch.empty(2, 4, device=self.device, dtype=dtype),
                 "M": 2,
                 "d": 4,
             }
@@ -80,10 +87,10 @@ class Challenge(ChallengeBase):
         # basic_example
         tests.append(
             {
-                "Q": torch.tensor([[0.0, 0.0], [1.0, 1.0]], device="cuda", dtype=dtype),
-                "K": torch.tensor([[1.0, 0.0], [0.0, 1.0]], device="cuda", dtype=dtype),
-                "V": torch.tensor([[3.0, 4.0], [5.0, 6.0]], device="cuda", dtype=dtype),
-                "output": torch.empty(2, 2, device="cuda", dtype=dtype),
+                "Q": torch.tensor([[0.0, 0.0], [1.0, 1.0]], device=self.device, dtype=dtype),
+                "K": torch.tensor([[1.0, 0.0], [0.0, 1.0]], device=self.device, dtype=dtype),
+                "V": torch.tensor([[3.0, 4.0], [5.0, 6.0]], device=self.device, dtype=dtype),
+                "output": torch.empty(2, 2, device=self.device, dtype=dtype),
                 "M": 2,
                 "d": 2,
             }
@@ -92,10 +99,10 @@ class Challenge(ChallengeBase):
         # zero_matrices
         tests.append(
             {
-                "Q": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "K": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "V": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "output": torch.empty(3, 5, device="cuda", dtype=dtype),
+                "Q": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "K": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "V": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "output": torch.empty(3, 5, device=self.device, dtype=dtype),
                 "M": 3,
                 "d": 5,
             }
@@ -106,20 +113,20 @@ class Challenge(ChallengeBase):
             {
                 "Q": torch.tensor(
                     [[-1.0, 2.0, -3.0], [4.0, -5.0, 6.0], [-7.0, 8.0, -9.0], [10.0, -11.0, 12.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "K": torch.tensor(
                     [[2.0, -1.0, 3.0], [-4.0, 5.0, -6.0], [7.0, -8.0, 9.0], [-10.0, 11.0, -12.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "V": torch.tensor(
                     [[1.0, 0.5, -0.5], [-1.0, 2.0, 3.0], [4.0, -2.0, 1.0], [0.0, 1.0, -1.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "output": torch.empty(4, 3, device="cuda", dtype=dtype),
+                "output": torch.empty(4, 3, device=self.device, dtype=dtype),
                 "M": 4,
                 "d": 3,
             }
@@ -128,10 +135,10 @@ class Challenge(ChallengeBase):
         # large_matrices
         tests.append(
             {
-                "Q": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "K": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "V": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "output": torch.empty(128, 32, device="cuda", dtype=dtype),
+                "Q": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "K": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "V": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "output": torch.empty(128, 32, device=self.device, dtype=dtype),
                 "M": 128,
                 "d": 32,
             }
@@ -142,8 +149,8 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         M, d = 10000, 128
-        Q = torch.empty((M, d), device="cuda", dtype=dtype).uniform_(-100, 100)
-        K = torch.empty((M, d), device="cuda", dtype=dtype).uniform_(-100, 100)
-        V = torch.empty((M, d), device="cuda", dtype=dtype).uniform_(-100, 100)
-        output = torch.empty(M, d, device="cuda", dtype=dtype)
+        Q = torch.empty((M, d), device=self.device, dtype=dtype).uniform_(-100, 100)
+        K = torch.empty((M, d), device=self.device, dtype=dtype).uniform_(-100, 100)
+        V = torch.empty((M, d), device=self.device, dtype=dtype).uniform_(-100, 100)
+        output = torch.empty(M, d, device=self.device, dtype=dtype)
         return {"Q": Q, "K": K, "V": V, "output": output, "M": M, "d": d}

--- a/challenges/hard/59_sliding_window_attn/challenge.py
+++ b/challenges/hard/59_sliding_window_attn/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Sliding Window Self-Attention",
-            atol=1e-05,
-            rtol=1e-05,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Sliding Window Self-Attention"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -50,10 +47,16 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        Q = torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype)
-        K = torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype)
-        V = torch.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device="cuda", dtype=dtype)
-        output = torch.empty(2, 4, device="cuda", dtype=dtype)
+        Q = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
+        )
+        K = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
+        )
+        V = torch.tensor(
+            [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device=self.device, dtype=dtype
+        )
+        output = torch.empty(2, 4, device=self.device, dtype=dtype)
         return {"Q": Q, "K": K, "V": V, "output": output, "M": 2, "d": 4, "window_size": 1}
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
@@ -64,15 +67,15 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "Q": torch.tensor(
-                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype
+                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
                 ),
                 "K": torch.tensor(
-                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype
+                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
                 ),
                 "V": torch.tensor(
-                    [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device="cuda", dtype=dtype
+                    [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], device=self.device, dtype=dtype
                 ),
-                "output": torch.empty(2, 4, device="cuda", dtype=dtype),
+                "output": torch.empty(2, 4, device=self.device, dtype=dtype),
                 "M": 2,
                 "d": 4,
                 "window_size": 1,
@@ -82,10 +85,16 @@ class Challenge(ChallengeBase):
         # basic_example
         tests.append(
             {
-                "Q": torch.tensor([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]], device="cuda", dtype=dtype),
-                "K": torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], device="cuda", dtype=dtype),
-                "V": torch.tensor([[1.0, 2.0, 3.0], [5.0, 6.0, 7.0]], device="cuda", dtype=dtype),
-                "output": torch.empty(2, 3, device="cuda", dtype=dtype),
+                "Q": torch.tensor(
+                    [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]], device=self.device, dtype=dtype
+                ),
+                "K": torch.tensor(
+                    [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], device=self.device, dtype=dtype
+                ),
+                "V": torch.tensor(
+                    [[1.0, 2.0, 3.0], [5.0, 6.0, 7.0]], device=self.device, dtype=dtype
+                ),
+                "output": torch.empty(2, 3, device=self.device, dtype=dtype),
                 "M": 2,
                 "d": 3,
                 "window_size": 1,
@@ -95,10 +104,10 @@ class Challenge(ChallengeBase):
         # zero_matrices
         tests.append(
             {
-                "Q": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "K": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "V": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "output": torch.empty(3, 5, device="cuda", dtype=dtype),
+                "Q": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "K": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "V": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "output": torch.empty(3, 5, device=self.device, dtype=dtype),
                 "M": 3,
                 "d": 5,
                 "window_size": 2,
@@ -110,20 +119,20 @@ class Challenge(ChallengeBase):
             {
                 "Q": torch.tensor(
                     [[-1.0, 2.0, -3.0], [4.0, -5.0, 6.0], [-7.0, 8.0, -9.0], [10.0, -11.0, 12.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "K": torch.tensor(
                     [[2.0, -1.0, 3.0], [-4.0, 5.0, -6.0], [7.0, -8.0, 9.0], [-10.0, 11.0, -12.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "V": torch.tensor(
                     [[1.0, 0.5, -0.5], [-1.0, 2.0, 3.0], [4.0, -2.0, 1.0], [0.0, 1.0, -1.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "output": torch.empty(4, 3, device="cuda", dtype=dtype),
+                "output": torch.empty(4, 3, device=self.device, dtype=dtype),
                 "M": 4,
                 "d": 3,
                 "window_size": 2,
@@ -133,10 +142,10 @@ class Challenge(ChallengeBase):
         # large_matrices
         tests.append(
             {
-                "Q": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "K": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "V": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "output": torch.empty(128, 32, device="cuda", dtype=dtype),
+                "Q": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "K": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "V": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "output": torch.empty(128, 32, device=self.device, dtype=dtype),
                 "M": 128,
                 "d": 32,
                 "window_size": 8,
@@ -148,10 +157,10 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         M, d, window_size = 5000, 64, 16
-        Q = torch.empty((M, d), device="cuda", dtype=dtype).uniform_(-100, 100)
-        K = torch.empty((M, d), device="cuda", dtype=dtype).uniform_(-100, 100)
-        V = torch.empty((M, d), device="cuda", dtype=dtype).uniform_(-100, 100)
-        output = torch.empty(M, d, device="cuda", dtype=dtype)
+        Q = torch.empty((M, d), device=self.device, dtype=dtype).uniform_(-100, 100)
+        K = torch.empty((M, d), device=self.device, dtype=dtype).uniform_(-100, 100)
+        V = torch.empty((M, d), device=self.device, dtype=dtype).uniform_(-100, 100)
+        output = torch.empty(M, d, device=self.device, dtype=dtype)
         return {
             "Q": Q,
             "K": K,

--- a/challenges/hard/73_all_pairs_shortest_paths/challenge.py
+++ b/challenges/hard/73_all_pairs_shortest_paths/challenge.py
@@ -5,37 +5,33 @@ import torch
 from core.challenge_base import ChallengeBase
 
 
-def _make_graph(N: int, density: float = 0.5, max_weight: float = 10.0, seed: int = None):
-    """Create a random non-negative weighted directed graph as a flat float32 CUDA tensor."""
+def _make_graph(N: int, device, density: float = 0.5, max_weight: float = 10.0, seed: int = None):
+    """Create a random non-negative weighted directed graph as a flat float32 tensor."""
     if seed is not None:
         torch.manual_seed(seed)
-    d = torch.full((N * N,), float("inf"), device="cuda", dtype=torch.float32)
+    d = torch.full((N * N,), float("inf"), device=device, dtype=torch.float32)
     d_view = d.view(N, N)
     d_view.fill_diagonal_(0.0)
     if N > 1:
-        mask = torch.rand(N, N, device="cuda") < density
+        mask = torch.rand(N, N, device=device) < density
         mask.fill_diagonal_(False)
-        weights = torch.rand(N, N, device="cuda") * max_weight + 0.1
+        weights = torch.rand(N, N, device=device) * max_weight + 0.1
         d_view[mask] = weights[mask]
     return d
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="All-Pairs Shortest Paths",
-            atol=1e-02,
-            rtol=1e-02,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "All-Pairs Shortest Paths"
+    atol = 0.01
+    rtol = 0.01
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, dist: torch.Tensor, output: torch.Tensor, N: int):
         assert dist.shape == (N * N,)
         assert output.shape == (N * N,)
         assert dist.dtype == output.dtype == torch.float32
         assert dist.device == output.device
-        assert dist.device.type == "cuda"
         d = dist.view(N, N).clone()
         for k in range(N):
             d = torch.minimum(d, d[:, k : k + 1] + d[k : k + 1, :])
@@ -54,12 +50,12 @@ class Challenge(ChallengeBase):
         inf = float("inf")
         dist = torch.tensor(
             [0.0, 5.0, inf, 10.0, inf, 0.0, 3.0, inf, inf, inf, 0.0, 1.0, inf, inf, inf, 0.0],
-            device="cuda",
+            device=self.device,
             dtype=torch.float32,
         )
         return {
             "dist": dist,
-            "output": torch.empty(16, device="cuda", dtype=torch.float32),
+            "output": torch.empty(16, device=self.device, dtype=torch.float32),
             "N": 4,
         }
 
@@ -68,14 +64,14 @@ class Challenge(ChallengeBase):
         inf = float("inf")
 
         def make_output(N):
-            return torch.empty(N * N, device="cuda", dtype=torch.float32)
+            return torch.empty(N * N, device=self.device, dtype=torch.float32)
 
         # --- Edge cases ---
 
         # N=1: single vertex
         tests.append(
             {
-                "dist": torch.tensor([0.0], device="cuda", dtype=torch.float32),
+                "dist": torch.tensor([0.0], device=self.device, dtype=torch.float32),
                 "output": make_output(1),
                 "N": 1,
             }
@@ -84,7 +80,7 @@ class Challenge(ChallengeBase):
         # N=2: disconnected graph (no edges between vertices)
         tests.append(
             {
-                "dist": torch.tensor([0.0, inf, inf, 0.0], device="cuda", dtype=torch.float32),
+                "dist": torch.tensor([0.0, inf, inf, 0.0], device=self.device, dtype=torch.float32),
                 "output": make_output(2),
                 "N": 2,
             }
@@ -93,7 +89,7 @@ class Challenge(ChallengeBase):
         # N=2: bidirectional edges
         tests.append(
             {
-                "dist": torch.tensor([0.0, 3.0, 7.0, 0.0], device="cuda", dtype=torch.float32),
+                "dist": torch.tensor([0.0, 3.0, 7.0, 0.0], device=self.device, dtype=torch.float32),
                 "output": make_output(2),
                 "N": 2,
             }
@@ -104,7 +100,7 @@ class Challenge(ChallengeBase):
             {
                 "dist": torch.tensor(
                     [0.0, 2.0, inf, inf, 0.0, 3.0, inf, inf, 0.0],
-                    device="cuda",
+                    device=self.device,
                     dtype=torch.float32,
                 ),
                 "output": make_output(3),
@@ -134,7 +130,7 @@ class Challenge(ChallengeBase):
                         inf,
                         0.0,
                     ],
-                    device="cuda",
+                    device=self.device,
                     dtype=torch.float32,
                 ),
                 "output": make_output(4),
@@ -166,7 +162,7 @@ class Challenge(ChallengeBase):
                         inf,
                         0.0,
                     ],
-                    device="cuda",
+                    device=self.device,
                     dtype=torch.float32,
                 ),
                 "output": make_output(4),
@@ -178,7 +174,7 @@ class Challenge(ChallengeBase):
         for N, seed in [(16, 1), (32, 2), (64, 3), (128, 4)]:
             tests.append(
                 {
-                    "dist": _make_graph(N, density=0.5, seed=seed),
+                    "dist": _make_graph(N, self.device, density=0.5, seed=seed),
                     "output": make_output(N),
                     "N": N,
                 }
@@ -188,7 +184,7 @@ class Challenge(ChallengeBase):
         for N, seed in [(30, 5), (100, 6), (255, 7)]:
             tests.append(
                 {
-                    "dist": _make_graph(N, density=0.4, seed=seed),
+                    "dist": _make_graph(N, self.device, density=0.4, seed=seed),
                     "output": make_output(N),
                     "N": N,
                 }
@@ -198,7 +194,7 @@ class Challenge(ChallengeBase):
         for N, seed in [(512, 8)]:
             tests.append(
                 {
-                    "dist": _make_graph(N, density=0.3, seed=seed),
+                    "dist": _make_graph(N, self.device, density=0.3, seed=seed),
                     "output": make_output(N),
                     "N": N,
                 }
@@ -208,7 +204,7 @@ class Challenge(ChallengeBase):
         N = 8
         tests.append(
             {
-                "dist": torch.zeros(N * N, device="cuda", dtype=torch.float32),
+                "dist": torch.zeros(N * N, device=self.device, dtype=torch.float32),
                 "output": make_output(N),
                 "N": N,
             }
@@ -219,7 +215,7 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         N = 2048
         return {
-            "dist": _make_graph(N, density=0.3, seed=42),
-            "output": torch.empty(N * N, device="cuda", dtype=torch.float32),
+            "dist": _make_graph(N, self.device, density=0.3, seed=42),
+            "output": torch.empty(N * N, device=self.device, dtype=torch.float32),
             "N": N,
         }

--- a/challenges/hard/74_gpt2_block/challenge.py
+++ b/challenges/hard/74_gpt2_block/challenge.py
@@ -29,14 +29,11 @@ TOTAL_WEIGHTS = O_BPROJ + D
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="GPT-2 Transformer Block",
-            atol=1e-03,
-            rtol=1e-03,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "GPT-2 Transformer Block"
+    atol = 0.001
+    rtol = 0.001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -49,9 +46,6 @@ class Challenge(ChallengeBase):
         assert output.shape == (seq_len, D)
         assert weights.shape == (TOTAL_WEIGHTS,)
         assert x.dtype == output.dtype == weights.dtype
-        assert x.device.type == "cuda"
-        assert output.device.type == "cuda"
-        assert weights.device.type == "cuda"
 
         # unpack weights
         ln1_w = weights[O_LN1_W:O_LN1_B]
@@ -143,7 +137,7 @@ class Challenge(ChallengeBase):
 
     def _make_test_case(self, seq_len, zero_x=False):
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         weights = self._make_weights(device, dtype)
         if zero_x:
             x = torch.zeros(seq_len, D, device=device, dtype=dtype)

--- a/challenges/hard/93_llama_transformer_block/challenge.py
+++ b/challenges/hard/93_llama_transformer_block/challenge.py
@@ -30,14 +30,11 @@ TOTAL_WEIGHTS = O_WDOWN + D * FFN_HIDDEN
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Llama Transformer Block",
-            atol=1e-03,
-            rtol=1e-03,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Llama Transformer Block"
+    atol = 0.001
+    rtol = 0.001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -54,11 +51,6 @@ class Challenge(ChallengeBase):
         assert cos.shape == (seq_len, HEAD_DIM // 2)
         assert sin.shape == (seq_len, HEAD_DIM // 2)
         assert x.dtype == output.dtype == weights.dtype == cos.dtype == sin.dtype
-        assert x.device.type == "cuda"
-        assert output.device.type == "cuda"
-        assert weights.device.type == "cuda"
-        assert cos.device.type == "cuda"
-        assert sin.device.type == "cuda"
 
         def rms_norm(z, w):
             return z * torch.rsqrt(z.pow(2).mean(-1, keepdim=True) + 1e-5) * w
@@ -175,7 +167,7 @@ class Challenge(ChallengeBase):
 
     def _make_test_case(self, seq_len, zero_x=False):
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         weights = self._make_weights(device, dtype)
         cos, sin = self._make_rope_tables(seq_len, device, dtype)
         if zero_x:

--- a/challenges/medium/10_2d_convolution/challenge.py
+++ b/challenges/medium/10_2d_convolution/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="2D Convolution", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "2D Convolution"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -47,10 +48,10 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         input = torch.tensor(
-            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], device="cuda", dtype=dtype
+            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], device=self.device, dtype=dtype
         )
-        kernel = torch.tensor([0.0, 1.0, 1.0, 0.0], device="cuda", dtype=dtype)
-        output = torch.empty(4, device="cuda", dtype=dtype)
+        kernel = torch.tensor([0.0, 1.0, 1.0, 0.0], device=self.device, dtype=dtype)
+        output = torch.empty(4, device=self.device, dtype=dtype)
         return {
             "input": input,
             "kernel": kernel,
@@ -68,10 +69,10 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "input": torch.tensor(
-                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], device="cuda", dtype=dtype
+                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], device=self.device, dtype=dtype
                 ),
-                "kernel": torch.tensor([0.0, 1.0, 1.0, 0.0], device="cuda", dtype=dtype),
-                "output": torch.empty(4, device="cuda", dtype=dtype),
+                "kernel": torch.tensor([0.0, 1.0, 1.0, 0.0], device=self.device, dtype=dtype),
+                "output": torch.empty(4, device=self.device, dtype=dtype),
                 "input_rows": 3,
                 "input_cols": 3,
                 "kernel_rows": 2,
@@ -81,9 +82,11 @@ class Challenge(ChallengeBase):
         # rectangular_input
         tests.append(
             {
-                "input": torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], device="cuda", dtype=dtype),
-                "kernel": torch.tensor([1.0, 0.0], device="cuda", dtype=dtype),
-                "output": torch.empty(4, device="cuda", dtype=dtype),
+                "input": torch.tensor(
+                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], device=self.device, dtype=dtype
+                ),
+                "kernel": torch.tensor([1.0, 0.0], device=self.device, dtype=dtype),
+                "output": torch.empty(4, device=self.device, dtype=dtype),
                 "input_rows": 2,
                 "input_cols": 3,
                 "kernel_rows": 1,
@@ -94,10 +97,10 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "input": torch.tensor(
-                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], device="cuda", dtype=dtype
+                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], device=self.device, dtype=dtype
                 ),
-                "kernel": torch.tensor([-1.0, 1.0, 0.0, 0.0], device="cuda", dtype=dtype),
-                "output": torch.empty(4, device="cuda", dtype=dtype),
+                "kernel": torch.tensor([-1.0, 1.0, 0.0, 0.0], device=self.device, dtype=dtype),
+                "output": torch.empty(4, device=self.device, dtype=dtype),
                 "input_rows": 3,
                 "input_cols": 3,
                 "kernel_rows": 2,
@@ -108,10 +111,10 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "input": torch.tensor(
-                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], device="cuda", dtype=dtype
+                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], device=self.device, dtype=dtype
                 ),
-                "kernel": torch.tensor([2.0], device="cuda", dtype=dtype),
-                "output": torch.empty(9, device="cuda", dtype=dtype),
+                "kernel": torch.tensor([2.0], device=self.device, dtype=dtype),
+                "output": torch.empty(9, device=self.device, dtype=dtype),
                 "input_rows": 3,
                 "input_cols": 3,
                 "kernel_rows": 1,
@@ -121,9 +124,9 @@ class Challenge(ChallengeBase):
         # medium_matrix_small_kernel
         tests.append(
             {
-                "input": torch.empty(64 * 64, device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "kernel": torch.empty(3 * 3, device="cuda", dtype=dtype).uniform_(-0.5, 0.5),
-                "output": torch.empty(62 * 62, device="cuda", dtype=dtype),
+                "input": torch.empty(64 * 64, device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "kernel": torch.empty(3 * 3, device=self.device, dtype=dtype).uniform_(-0.5, 0.5),
+                "output": torch.empty(62 * 62, device=self.device, dtype=dtype),
                 "input_rows": 64,
                 "input_cols": 64,
                 "kernel_rows": 3,
@@ -133,9 +136,11 @@ class Challenge(ChallengeBase):
         # large_matrix_medium_kernel
         tests.append(
             {
-                "input": torch.empty(128 * 128, device="cuda", dtype=dtype).uniform_(-2.0, 2.0),
-                "kernel": torch.empty(7 * 7, device="cuda", dtype=dtype).uniform_(-0.2, 0.2),
-                "output": torch.empty(122 * 122, device="cuda", dtype=dtype),
+                "input": torch.empty(128 * 128, device=self.device, dtype=dtype).uniform_(
+                    -2.0, 2.0
+                ),
+                "kernel": torch.empty(7 * 7, device=self.device, dtype=dtype).uniform_(-0.2, 0.2),
+                "output": torch.empty(122 * 122, device=self.device, dtype=dtype),
                 "input_rows": 128,
                 "input_cols": 128,
                 "kernel_rows": 7,
@@ -145,9 +150,11 @@ class Challenge(ChallengeBase):
         # rectangular_large_matrix
         tests.append(
             {
-                "input": torch.empty(128 * 256, device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "kernel": torch.empty(5 * 5, device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "output": torch.empty(124 * 252, device="cuda", dtype=dtype),
+                "input": torch.empty(128 * 256, device=self.device, dtype=dtype).uniform_(
+                    -1.0, 1.0
+                ),
+                "kernel": torch.empty(5 * 5, device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "output": torch.empty(124 * 252, device=self.device, dtype=dtype),
                 "input_rows": 128,
                 "input_cols": 256,
                 "kernel_rows": 5,
@@ -162,13 +169,15 @@ class Challenge(ChallengeBase):
         input_cols = 3072
         kernel_rows = 15
         kernel_cols = 15
-        input = torch.empty(input_rows * input_cols, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        kernel = torch.empty(kernel_rows * kernel_cols, device="cuda", dtype=dtype).uniform_(
+        input = torch.empty(input_rows * input_cols, device=self.device, dtype=dtype).uniform_(
+            -1.0, 1.0
+        )
+        kernel = torch.empty(kernel_rows * kernel_cols, device=self.device, dtype=dtype).uniform_(
             -1.0, 1.0
         )
         output_rows = input_rows - kernel_rows + 1
         output_cols = input_cols - kernel_cols + 1
-        output = torch.empty(output_rows * output_cols, device="cuda", dtype=dtype)
+        output = torch.empty(output_rows * output_cols, device=self.device, dtype=dtype)
         return {
             "input": input,
             "kernel": kernel,

--- a/challenges/medium/11_3d_convolution/challenge.py
+++ b/challenges/medium/11_3d_convolution/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="3D Convolution", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "3D Convolution"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -64,14 +65,14 @@ class Challenge(ChallengeBase):
                 [[19, 20, 21], [22, 23, 24], [25, 26, 27]],
             ],
             dtype=dtype,
-            device="cuda",
+            device=self.device,
         )
         kernel_tensor = torch.tensor(
             [[[1, 0, 0], [1, 1, 1], [0, 0, 0]], [[1, 1, 0], [1, 1, 0], [0, 0, 1]]],
             dtype=dtype,
-            device="cuda",
+            device=self.device,
         )
-        output_tensor = torch.empty((2, 1, 1), device="cuda", dtype=dtype)
+        output_tensor = torch.empty((2, 1, 1), device=self.device, dtype=dtype)
         return {
             "input": input_tensor,
             "kernel": kernel_tensor,
@@ -86,7 +87,7 @@ class Challenge(ChallengeBase):
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         tests = []
 
         # basic_example
@@ -245,16 +246,16 @@ class Challenge(ChallengeBase):
         input_depth, input_rows, input_cols = 256, 128, 128
         kernel_depth, kernel_rows, kernel_cols = 5, 5, 5
         input_tensor = torch.empty(
-            input_depth, input_rows, input_cols, device="cuda", dtype=dtype
+            input_depth, input_rows, input_cols, device=self.device, dtype=dtype
         ).uniform_(-1.0, 1.0)
         kernel_tensor = torch.empty(
-            kernel_depth, kernel_rows, kernel_cols, device="cuda", dtype=dtype
+            kernel_depth, kernel_rows, kernel_cols, device=self.device, dtype=dtype
         ).uniform_(-1.0, 1.0)
         output_tensor = torch.zeros(
             input_depth - kernel_depth + 1,
             input_rows - kernel_rows + 1,
             input_cols - kernel_cols + 1,
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
         return {

--- a/challenges/medium/13_histogramming/challenge.py
+++ b/challenges/medium/13_histogramming/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Histogramming", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Histogramming"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, histogram: torch.Tensor, N: int, num_bins: int):
         # Validate input types and shapes
@@ -35,8 +36,8 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.tensor([0, 1, 2, 1, 0], device="cuda", dtype=dtype)
-        histogram = torch.empty(3, device="cuda", dtype=dtype)
+        input = torch.tensor([0, 1, 2, 1, 0], device=self.device, dtype=dtype)
+        histogram = torch.empty(3, device=self.device, dtype=dtype)
         return {
             "input": input,
             "histogram": histogram,
@@ -51,8 +52,8 @@ class Challenge(ChallengeBase):
         # basic_example
         tests.append(
             {
-                "input": torch.tensor([0, 1, 2, 1, 0], device="cuda", dtype=dtype),
-                "histogram": torch.zeros(3, device="cuda", dtype=dtype),
+                "input": torch.tensor([0, 1, 2, 1, 0], device=self.device, dtype=dtype),
+                "histogram": torch.zeros(3, device=self.device, dtype=dtype),
                 "N": 5,
                 "num_bins": 3,
             }
@@ -61,8 +62,8 @@ class Challenge(ChallengeBase):
         # all_same_value
         tests.append(
             {
-                "input": torch.tensor([2] * 16, device="cuda", dtype=dtype),
-                "histogram": torch.zeros(5, device="cuda", dtype=dtype),
+                "input": torch.tensor([2] * 16, device=self.device, dtype=dtype),
+                "histogram": torch.zeros(5, device=self.device, dtype=dtype),
                 "N": 16,
                 "num_bins": 5,
             }
@@ -71,8 +72,8 @@ class Challenge(ChallengeBase):
         # increasing_sequence
         tests.append(
             {
-                "input": torch.randint(0, 4, (32,), device="cuda", dtype=dtype),
-                "histogram": torch.zeros(4, device="cuda", dtype=dtype),
+                "input": torch.randint(0, 4, (32,), device=self.device, dtype=dtype),
+                "histogram": torch.zeros(4, device=self.device, dtype=dtype),
                 "N": 32,
                 "num_bins": 4,
             }
@@ -81,8 +82,8 @@ class Challenge(ChallengeBase):
         # medium_size
         tests.append(
             {
-                "input": torch.randint(0, 10, (1000,), device="cuda", dtype=dtype),
-                "histogram": torch.zeros(10, device="cuda", dtype=dtype),
+                "input": torch.randint(0, 10, (1000,), device=self.device, dtype=dtype),
+                "histogram": torch.zeros(10, device=self.device, dtype=dtype),
                 "N": 1000,
                 "num_bins": 10,
             }
@@ -91,8 +92,8 @@ class Challenge(ChallengeBase):
         # large_multi_block
         tests.append(
             {
-                "input": torch.randint(0, 128, (10000,), device="cuda", dtype=dtype),
-                "histogram": torch.zeros(128, device="cuda", dtype=dtype),
+                "input": torch.randint(0, 128, (10000,), device=self.device, dtype=dtype),
+                "histogram": torch.zeros(128, device=self.device, dtype=dtype),
                 "N": 10000,
                 "num_bins": 128,
             }
@@ -102,8 +103,8 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.randint(0, 256, (50000000,), device="cuda", dtype=dtype)
-        histogram = torch.zeros(256, device="cuda", dtype=dtype)
+        input = torch.randint(0, 256, (50000000,), device=self.device, dtype=dtype)
+        histogram = torch.zeros(256, device=self.device, dtype=dtype)
         return {
             "input": input,
             "histogram": histogram,

--- a/challenges/medium/16_prefix_sum/challenge.py
+++ b/challenges/medium/16_prefix_sum/challenge.py
@@ -6,8 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(name="Prefix Sum", atol=1e-02, rtol=1e-02, num_gpus=1, access_tier="free")
+    name = "Prefix Sum"
+    atol = 0.01
+    rtol = 0.01
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int):
         assert input.shape == (N,)
@@ -24,8 +27,8 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        input = torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype)
-        output = torch.empty(4, device="cuda", dtype=dtype)
+        input = torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype)
+        output = torch.empty(4, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,
@@ -38,24 +41,24 @@ class Challenge(ChallengeBase):
         # basic_example
         tests.append(
             {
-                "input": torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype),
-                "output": torch.empty(4, device="cuda", dtype=dtype),
+                "input": torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype),
+                "output": torch.empty(4, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
         # mixed_signs
         tests.append(
             {
-                "input": torch.tensor([5.0, -2.0, 3.0, 1.0, -4.0], device="cuda", dtype=dtype),
-                "output": torch.empty(5, device="cuda", dtype=dtype),
+                "input": torch.tensor([5.0, -2.0, 3.0, 1.0, -4.0], device=self.device, dtype=dtype),
+                "output": torch.empty(5, device=self.device, dtype=dtype),
                 "N": 5,
             }
         )
         # single_element
         tests.append(
             {
-                "input": torch.tensor([42.0], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([42.0], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1,
             }
         )
@@ -63,25 +66,25 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "input": torch.tensor(
-                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], device="cuda", dtype=dtype
+                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], device=self.device, dtype=dtype
                 ),
-                "output": torch.empty(8, device="cuda", dtype=dtype),
+                "output": torch.empty(8, device=self.device, dtype=dtype),
                 "N": 8,
             }
         )
         # all_zeros
         tests.append(
             {
-                "input": torch.empty(1024, device="cuda", dtype=dtype).zero_(),
-                "output": torch.empty(1024, device="cuda", dtype=dtype),
+                "input": torch.empty(1024, device=self.device, dtype=dtype).zero_(),
+                "output": torch.empty(1024, device=self.device, dtype=dtype),
                 "N": 1024,
             }
         )
         # random_large
         tests.append(
             {
-                "input": torch.empty(2025, device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-                "output": torch.empty(2025, device="cuda", dtype=dtype),
+                "input": torch.empty(2025, device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
+                "output": torch.empty(2025, device=self.device, dtype=dtype),
                 "N": 2025,
             }
         )
@@ -90,8 +93,8 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 250000
-        input = torch.empty(N, device="cuda", dtype=dtype).uniform_(-100.0, 100.0)
-        output = torch.empty(N, device="cuda", dtype=dtype)
+        input = torch.empty(N, device=self.device, dtype=dtype).uniform_(-100.0, 100.0)
+        output = torch.empty(N, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,

--- a/challenges/medium/17_dot_product/challenge.py
+++ b/challenges/medium/17_dot_product/challenge.py
@@ -6,8 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(name="Dot Product", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free")
+    name = "Dot Product"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, A: torch.Tensor, B: torch.Tensor, result: torch.Tensor, N: int):
         assert A.shape == (N,)
@@ -25,9 +28,9 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        A = torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype)
-        B = torch.tensor([5.0, 6.0, 7.0, 8.0], device="cuda", dtype=dtype)
-        result = torch.empty(1, device="cuda", dtype=dtype)
+        A = torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype)
+        B = torch.tensor([5.0, 6.0, 7.0, 8.0], device=self.device, dtype=dtype)
+        result = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "A": A,
             "B": B,
@@ -41,63 +44,63 @@ class Challenge(ChallengeBase):
         # basic_small
         tests.append(
             {
-                "A": torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([5.0, 6.0, 7.0, 8.0], device="cuda", dtype=dtype),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([5.0, 6.0, 7.0, 8.0], device=self.device, dtype=dtype),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
         # all_zeros
         tests.append(
             {
-                "A": torch.tensor([0.0] * 16, device="cuda", dtype=dtype),
-                "B": torch.tensor([0.0] * 16, device="cuda", dtype=dtype),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.tensor([0.0] * 16, device=self.device, dtype=dtype),
+                "B": torch.tensor([0.0] * 16, device=self.device, dtype=dtype),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 16,
             }
         )
         # negative_numbers
         tests.append(
             {
-                "A": torch.tensor([-1.0, -2.0, -3.0, -4.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([-5.0, -6.0, -7.0, -8.0], device="cuda", dtype=dtype),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.tensor([-1.0, -2.0, -3.0, -4.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([-5.0, -6.0, -7.0, -8.0], device=self.device, dtype=dtype),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
         # mixed_positive_negative
         tests.append(
             {
-                "A": torch.tensor([1.0, -2.0, 3.0, -4.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([-1.0, 2.0, -3.0, 4.0], device="cuda", dtype=dtype),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.tensor([1.0, -2.0, 3.0, -4.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([-1.0, 2.0, -3.0, 4.0], device=self.device, dtype=dtype),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
         # orthogonal_vectors
         tests.append(
             {
-                "A": torch.tensor([1.0, 0.0, 0.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([0.0, 1.0, 0.0], device="cuda", dtype=dtype),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.tensor([1.0, 0.0, 0.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([0.0, 1.0, 0.0], device=self.device, dtype=dtype),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 3,
             }
         )
         # medium_sized_vector
         tests.append(
             {
-                "A": torch.empty(1000, device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "B": torch.empty(1000, device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.empty(1000, device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "B": torch.empty(1000, device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1000,
             }
         )
         # large_vector
         tests.append(
             {
-                "A": torch.empty(10000, device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "B": torch.empty(10000, device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.empty(10000, device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "B": torch.empty(10000, device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 10000,
             }
         )
@@ -106,9 +109,9 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 5
-        A = torch.empty(N, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        B = torch.empty(N, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        result = torch.zeros(1, device="cuda", dtype=dtype)
+        A = torch.empty(N, device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        B = torch.empty(N, device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        result = torch.zeros(1, device=self.device, dtype=dtype)
         return {
             "A": A,
             "B": B,

--- a/challenges/medium/18_sparse_matrix_vector_multiplication/challenge.py
+++ b/challenges/medium/18_sparse_matrix_vector_multiplication/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Sparse Matrix-Vector Multiplication",
-            atol=1e-03,
-            rtol=1e-03,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Sparse Matrix-Vector Multiplication"
+    atol = 0.001
+    rtol = 0.001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self, A: torch.Tensor, x: torch.Tensor, y: torch.Tensor, M: int, N: int, nnz: int
@@ -43,10 +40,12 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         A = torch.tensor(
-            [5.0, 0.0, 0.0, 1.0, 0.0, 2.0, 3.0, 0.0, 0.0, 0.0, 0.0, 4.0], device="cuda", dtype=dtype
+            [5.0, 0.0, 0.0, 1.0, 0.0, 2.0, 3.0, 0.0, 0.0, 0.0, 0.0, 4.0],
+            device=self.device,
+            dtype=dtype,
         )
-        x = torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype)
-        y = torch.empty(3, device="cuda", dtype=dtype)
+        x = torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype)
+        y = torch.empty(3, device=self.device, dtype=dtype)
         return {
             "A": A,
             "x": x,
@@ -62,9 +61,9 @@ class Challenge(ChallengeBase):
         # small_test
         tests.append(
             {
-                "A": torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="cuda", dtype=dtype),
-                "x": torch.tensor([1.0, 1.0], device="cuda", dtype=dtype),
-                "y": torch.empty(2, device="cuda", dtype=dtype),
+                "A": torch.tensor([[1.0, 2.0], [3.0, 4.0]], device=self.device, dtype=dtype),
+                "x": torch.tensor([1.0, 1.0], device=self.device, dtype=dtype),
+                "y": torch.empty(2, device=self.device, dtype=dtype),
                 "M": 2,
                 "N": 2,
                 "nnz": 4,
@@ -74,10 +73,12 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "A": torch.tensor(
-                    [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], device="cuda", dtype=dtype
+                    [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+                    device=self.device,
+                    dtype=dtype,
                 ),
-                "x": torch.tensor([1.0, 2.0, 3.0], device="cuda", dtype=dtype),
-                "y": torch.empty(3, device="cuda", dtype=dtype),
+                "x": torch.tensor([1.0, 2.0, 3.0], device=self.device, dtype=dtype),
+                "y": torch.empty(3, device=self.device, dtype=dtype),
                 "M": 3,
                 "N": 3,
                 "nnz": 3,
@@ -86,9 +87,9 @@ class Challenge(ChallengeBase):
         # zero_test
         tests.append(
             {
-                "A": torch.zeros((2, 3), device="cuda", dtype=dtype),
-                "x": torch.tensor([1.0, 2.0, 3.0], device="cuda", dtype=dtype),
-                "y": torch.empty(2, device="cuda", dtype=dtype),
+                "A": torch.zeros((2, 3), device=self.device, dtype=dtype),
+                "x": torch.tensor([1.0, 2.0, 3.0], device=self.device, dtype=dtype),
+                "y": torch.empty(2, device=self.device, dtype=dtype),
                 "M": 2,
                 "N": 3,
                 "nnz": 0,
@@ -99,11 +100,11 @@ class Challenge(ChallengeBase):
             {
                 "A": torch.tensor(
                     [[1.0, 0.0, 0.0, 0.0], [0.0, 2.0, 0.0, 0.0], [0.0, 0.0, 3.0, 0.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "x": torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype),
-                "y": torch.empty(3, device="cuda", dtype=dtype),
+                "x": torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype),
+                "y": torch.empty(3, device=self.device, dtype=dtype),
                 "M": 3,
                 "N": 4,
                 "nnz": 3,
@@ -113,10 +114,10 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "A": torch.tensor(
-                    [[-1.0, -2.0, -3.0], [-4.0, -5.0, -6.0]], device="cuda", dtype=dtype
+                    [[-1.0, -2.0, -3.0], [-4.0, -5.0, -6.0]], device=self.device, dtype=dtype
                 ),
-                "x": torch.tensor([-1.0, -2.0, -3.0], device="cuda", dtype=dtype),
-                "y": torch.empty(2, device="cuda", dtype=dtype),
+                "x": torch.tensor([-1.0, -2.0, -3.0], device=self.device, dtype=dtype),
+                "y": torch.empty(2, device=self.device, dtype=dtype),
                 "M": 2,
                 "N": 3,
                 "nnz": 6,
@@ -208,13 +209,13 @@ class Challenge(ChallengeBase):
                         0.0,
                         4.0,
                     ],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "x": torch.tensor(
-                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], device="cuda", dtype=dtype
+                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], device=self.device, dtype=dtype
                 ),
-                "y": torch.empty(10, device="cuda", dtype=dtype),
+                "y": torch.empty(10, device=self.device, dtype=dtype),
                 "M": 10,
                 "N": 8,
                 "nnz": 35,
@@ -227,16 +228,18 @@ class Challenge(ChallengeBase):
         sparsity = 0.65
 
         # Generate random sparse matrix
-        A_dense = torch.empty((M_sparse, N_sparse), device="cuda", dtype=dtype).uniform_(-5.0, 5.0)
-        mask = torch.rand((M_sparse, N_sparse), device="cuda") > sparsity
+        A_dense = torch.empty((M_sparse, N_sparse), device=self.device, dtype=dtype).uniform_(
+            -5.0, 5.0
+        )
+        mask = torch.rand((M_sparse, N_sparse), device=self.device) > sparsity
         A_sparse = A_dense * mask
         nnz_sparse = int(mask.sum().item())
 
         tests.append(
             {
                 "A": A_sparse,
-                "x": torch.empty(N_sparse, device="cuda", dtype=dtype).uniform_(-2.0, 2.0),
-                "y": torch.zeros(M_sparse, device="cuda", dtype=dtype),
+                "x": torch.empty(N_sparse, device=self.device, dtype=dtype).uniform_(-2.0, 2.0),
+                "y": torch.zeros(M_sparse, device=self.device, dtype=dtype),
                 "M": M_sparse,
                 "N": N_sparse,
                 "nnz": nnz_sparse,
@@ -250,15 +253,15 @@ class Challenge(ChallengeBase):
         M = 1000
         N = 10000
         nnz = 3500000
-        A = torch.zeros((M, N), device="cuda", dtype=dtype)
+        A = torch.zeros((M, N), device=self.device, dtype=dtype)
         total_elements = M * N
-        flat_indices = torch.randperm(total_elements, device="cuda")[:nnz]
-        values = torch.empty(nnz, device="cuda", dtype=dtype).uniform_(-10.0, 10.0)
+        flat_indices = torch.randperm(total_elements, device=self.device)[:nnz]
+        values = torch.empty(nnz, device=self.device, dtype=dtype).uniform_(-10.0, 10.0)
         A.view(-1)[flat_indices] = values
 
         # Create a mask: 35% entries will be kept, 65% set to zero
-        x = torch.empty(N, device="cuda", dtype=dtype).uniform_(-5.0, 5.0)
-        y = torch.empty(M, device="cuda", dtype=dtype)
+        x = torch.empty(N, device=self.device, dtype=dtype).uniform_(-5.0, 5.0)
+        y = torch.empty(M, device=self.device, dtype=dtype)
         return {
             "A": A,
             "x": x,

--- a/challenges/medium/22_gemm/challenge.py
+++ b/challenges/medium/22_gemm/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="General Matrix Multiplication (GEMM)",
-            atol=5e-2,
-            rtol=5e-2,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "General Matrix Multiplication (GEMM)"
+    atol = 0.05
+    rtol = 0.05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -50,9 +47,9 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float16
-        A = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device="cuda", dtype=dtype)
-        B = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], device="cuda", dtype=dtype)
-        C = torch.tensor([[1.0, 1.0], [1.0, 1.0]], device="cuda", dtype=dtype)
+        A = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], device=self.device, dtype=dtype)
+        B = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], device=self.device, dtype=dtype)
+        C = torch.tensor([[1.0, 1.0], [1.0, 1.0]], device=self.device, dtype=dtype)
         return {
             "A": A,
             "B": B,
@@ -71,9 +68,9 @@ class Challenge(ChallengeBase):
         # 16x16x16_a1_b0
         tests.append(
             {
-                "A": torch.empty((16, 16), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "B": torch.empty((16, 16), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "C": torch.zeros((16, 16), device="cuda", dtype=dtype),
+                "A": torch.empty((16, 16), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "B": torch.empty((16, 16), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "C": torch.zeros((16, 16), device=self.device, dtype=dtype),
                 "M": 16,
                 "N": 16,
                 "K": 16,
@@ -85,9 +82,9 @@ class Challenge(ChallengeBase):
         # 16x16x16_a1_b1
         tests.append(
             {
-                "A": torch.empty((16, 16), device="cuda", dtype=dtype).uniform_(-0.5, 0.5),
-                "B": torch.empty((16, 16), device="cuda", dtype=dtype).uniform_(-0.5, 0.5),
-                "C": torch.empty((16, 16), device="cuda", dtype=dtype).uniform_(-0.5, 0.5),
+                "A": torch.empty((16, 16), device=self.device, dtype=dtype).uniform_(-0.5, 0.5),
+                "B": torch.empty((16, 16), device=self.device, dtype=dtype).uniform_(-0.5, 0.5),
+                "C": torch.empty((16, 16), device=self.device, dtype=dtype).uniform_(-0.5, 0.5),
                 "M": 16,
                 "N": 16,
                 "K": 16,
@@ -99,9 +96,9 @@ class Challenge(ChallengeBase):
         # 32x16x16_a0.5_b0.5
         tests.append(
             {
-                "A": torch.empty((32, 16), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "B": torch.empty((16, 16), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "C": torch.empty((32, 16), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
+                "A": torch.empty((32, 16), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "B": torch.empty((16, 16), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "C": torch.empty((32, 16), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
                 "M": 32,
                 "N": 16,
                 "K": 16,
@@ -113,9 +110,9 @@ class Challenge(ChallengeBase):
         # 16x32x16_a1_b1
         tests.append(
             {
-                "A": torch.empty((16, 16), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "B": torch.empty((16, 32), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "C": torch.empty((16, 32), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
+                "A": torch.empty((16, 16), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "B": torch.empty((16, 32), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "C": torch.empty((16, 32), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
                 "M": 16,
                 "N": 32,
                 "K": 16,
@@ -127,9 +124,9 @@ class Challenge(ChallengeBase):
         # 16x16x32_a0_b1
         tests.append(
             {
-                "A": torch.empty((16, 32), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "B": torch.empty((32, 16), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "C": torch.empty((16, 16), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
+                "A": torch.empty((16, 32), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "B": torch.empty((32, 16), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "C": torch.empty((16, 16), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
                 "M": 16,
                 "N": 16,
                 "K": 32,
@@ -145,9 +142,9 @@ class Challenge(ChallengeBase):
         M = 1024
         N = 1024
         K = 1024
-        A = torch.empty((M, K), device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        B = torch.empty((K, N), device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        C = torch.empty((M, N), device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
+        A = torch.empty((M, K), device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        B = torch.empty((K, N), device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        C = torch.empty((M, N), device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
         return {
             "A": A,
             "B": B,

--- a/challenges/medium/25_categorical_cross_entropy_loss/challenge.py
+++ b/challenges/medium/25_categorical_cross_entropy_loss/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Categorical Cross Entropy Loss",
-            atol=1e-05,
-            rtol=1e-05,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Categorical Cross Entropy Loss"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self, logits: torch.Tensor, true_labels: torch.Tensor, loss: torch.Tensor, N: int, C: int
@@ -48,9 +45,11 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype_logits = torch.float32
         dtype_labels = torch.int32
-        logits = torch.tensor([[1.0, 2.0, 0.5], [0.1, 3.0, 1.5]], device="cuda", dtype=dtype_logits)
-        true_labels = torch.tensor([1, 1], device="cuda", dtype=dtype_labels)
-        loss = torch.zeros(1, device="cuda", dtype=dtype_logits)
+        logits = torch.tensor(
+            [[1.0, 2.0, 0.5], [0.1, 3.0, 1.5]], device=self.device, dtype=dtype_logits
+        )
+        true_labels = torch.tensor([1, 1], device=self.device, dtype=dtype_labels)
+        loss = torch.zeros(1, device=self.device, dtype=dtype_logits)
         return {
             "logits": logits,
             "true_labels": true_labels,
@@ -67,10 +66,10 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "logits": torch.tensor(
-                    [[1.0, 2.0, 0.5], [0.1, 3.0, 1.5]], device="cuda", dtype=dtype_logits
+                    [[1.0, 2.0, 0.5], [0.1, 3.0, 1.5]], device=self.device, dtype=dtype_logits
                 ),
-                "true_labels": torch.tensor([1, 1], device="cuda", dtype=dtype_labels),
-                "loss": torch.zeros(1, device="cuda", dtype=dtype_logits),
+                "true_labels": torch.tensor([1, 1], device=self.device, dtype=dtype_labels),
+                "loss": torch.zeros(1, device=self.device, dtype=dtype_logits),
                 "N": 2,
                 "C": 3,
             }
@@ -80,11 +79,11 @@ class Challenge(ChallengeBase):
             {
                 "logits": torch.tensor(
                     [[-0.5, 1.5, 0.0, 1.0], [2.0, -1.0, 0.5, 0.5], [0.0, 0.0, 0.0, 0.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype_logits,
                 ),
-                "true_labels": torch.tensor([3, 0, 1], device="cuda", dtype=dtype_labels),
-                "loss": torch.zeros(1, device="cuda", dtype=dtype_logits),
+                "true_labels": torch.tensor([3, 0, 1], device=self.device, dtype=dtype_labels),
+                "loss": torch.zeros(1, device=self.device, dtype=dtype_logits),
                 "N": 3,
                 "C": 4,
             }
@@ -93,10 +92,10 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "logits": torch.tensor(
-                    [[0.1, 0.2, 0.3, 0.4, 0.5]], device="cuda", dtype=dtype_logits
+                    [[0.1, 0.2, 0.3, 0.4, 0.5]], device=self.device, dtype=dtype_logits
                 ),
-                "true_labels": torch.tensor([4], device="cuda", dtype=dtype_labels),
-                "loss": torch.zeros(1, device="cuda", dtype=dtype_logits),
+                "true_labels": torch.tensor([4], device=self.device, dtype=dtype_labels),
+                "loss": torch.zeros(1, device=self.device, dtype=dtype_logits),
                 "N": 1,
                 "C": 5,
             }
@@ -104,9 +103,11 @@ class Challenge(ChallengeBase):
         # uniform_logits_correct_label
         tests.append(
             {
-                "logits": torch.tensor([[1.0] * 5, [1.0] * 5], device="cuda", dtype=dtype_logits),
-                "true_labels": torch.tensor([0, 0], device="cuda", dtype=dtype_labels),
-                "loss": torch.zeros(1, device="cuda", dtype=dtype_logits),
+                "logits": torch.tensor(
+                    [[1.0] * 5, [1.0] * 5], device=self.device, dtype=dtype_logits
+                ),
+                "true_labels": torch.tensor([0, 0], device=self.device, dtype=dtype_labels),
+                "loss": torch.zeros(1, device=self.device, dtype=dtype_logits),
                 "N": 2,
                 "C": 5,
             }
@@ -116,11 +117,11 @@ class Challenge(ChallengeBase):
             {
                 "logits": torch.tensor(
                     [[-5.0, -5.0, 10.0, -5.0], [10.0, -5.0, -5.0, -5.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype_logits,
                 ),
-                "true_labels": torch.tensor([2, 0], device="cuda", dtype=dtype_labels),
-                "loss": torch.zeros(1, device="cuda", dtype=dtype_logits),
+                "true_labels": torch.tensor([2, 0], device=self.device, dtype=dtype_labels),
+                "loss": torch.zeros(1, device=self.device, dtype=dtype_logits),
                 "N": 2,
                 "C": 4,
             }
@@ -129,10 +130,10 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "logits": torch.tensor(
-                    [[10.0, -5.0, -5.0], [-5.0, 10.0, -5.0]], device="cuda", dtype=dtype_logits
+                    [[10.0, -5.0, -5.0], [-5.0, 10.0, -5.0]], device=self.device, dtype=dtype_logits
                 ),
-                "true_labels": torch.tensor([1, 2], device="cuda", dtype=dtype_labels),
-                "loss": torch.zeros(1, device="cuda", dtype=dtype_logits),
+                "true_labels": torch.tensor([1, 2], device=self.device, dtype=dtype_labels),
+                "loss": torch.zeros(1, device=self.device, dtype=dtype_logits),
                 "N": 2,
                 "C": 3,
             }
@@ -140,11 +141,11 @@ class Challenge(ChallengeBase):
         # larger_batch_random
         tests.append(
             {
-                "logits": torch.empty(100, 5, device="cuda", dtype=dtype_logits).uniform_(
+                "logits": torch.empty(100, 5, device=self.device, dtype=dtype_logits).uniform_(
                     -5.0, 5.0
                 ),
-                "true_labels": torch.randint(0, 5, (100,), device="cuda", dtype=dtype_labels),
-                "loss": torch.zeros(1, device="cuda", dtype=dtype_logits),
+                "true_labels": torch.randint(0, 5, (100,), device=self.device, dtype=dtype_labels),
+                "loss": torch.zeros(1, device=self.device, dtype=dtype_logits),
                 "N": 100,
                 "C": 5,
             }
@@ -154,9 +155,11 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype_logits = torch.float32
         dtype_labels = torch.int32
-        logits = torch.empty(10000, 1000, device="cuda", dtype=dtype_logits).uniform_(-10.0, 10.0)
-        true_labels = torch.randint(0, 1000, (10000,), device="cuda", dtype=dtype_labels)
-        loss = torch.zeros(1, device="cuda", dtype=dtype_logits)
+        logits = torch.empty(10000, 1000, device=self.device, dtype=dtype_logits).uniform_(
+            -10.0, 10.0
+        )
+        true_labels = torch.randint(0, 1000, (10000,), device=self.device, dtype=dtype_labels)
+        loss = torch.zeros(1, device=self.device, dtype=dtype_logits)
         return {
             "logits": logits,
             "true_labels": true_labels,

--- a/challenges/medium/27_mean_squared_error/challenge.py
+++ b/challenges/medium/27_mean_squared_error/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Mean Squared Error", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Mean Squared Error"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self, predictions: torch.Tensor, targets: torch.Tensor, mse: torch.Tensor, N: int
@@ -29,9 +30,9 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        predictions = torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype)
-        targets = torch.tensor([1.5, 2.5, 3.5, 4.5], device="cuda", dtype=dtype)
-        mse = torch.empty(1, device="cuda", dtype=dtype)
+        predictions = torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype)
+        targets = torch.tensor([1.5, 2.5, 3.5, 4.5], device=self.device, dtype=dtype)
+        mse = torch.empty(1, device=self.device, dtype=dtype)
         N = 4
         return {
             "predictions": predictions,
@@ -46,68 +47,72 @@ class Challenge(ChallengeBase):
         # Test 1: basic_example
         tests.append(
             {
-                "predictions": torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype),
-                "targets": torch.tensor([1.5, 2.5, 3.5, 4.5], device="cuda", dtype=dtype),
-                "mse": torch.empty(1, device="cuda", dtype=dtype),
+                "predictions": torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype),
+                "targets": torch.tensor([1.5, 2.5, 3.5, 4.5], device=self.device, dtype=dtype),
+                "mse": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
         # Test 2: second_example
         tests.append(
             {
-                "predictions": torch.tensor([10.0, 20.0, 30.0], device="cuda", dtype=dtype),
-                "targets": torch.tensor([12.0, 18.0, 33.0], device="cuda", dtype=dtype),
-                "mse": torch.empty(1, device="cuda", dtype=dtype),
+                "predictions": torch.tensor([10.0, 20.0, 30.0], device=self.device, dtype=dtype),
+                "targets": torch.tensor([12.0, 18.0, 33.0], device=self.device, dtype=dtype),
+                "mse": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 3,
             }
         )
         # Test 3: zero_error
         tests.append(
             {
-                "predictions": torch.tensor([1.5, 2.5, 3.5, 4.5, 5.5], device="cuda", dtype=dtype),
-                "targets": torch.tensor([1.5, 2.5, 3.5, 4.5, 5.5], device="cuda", dtype=dtype),
-                "mse": torch.empty(1, device="cuda", dtype=dtype),
+                "predictions": torch.tensor(
+                    [1.5, 2.5, 3.5, 4.5, 5.5], device=self.device, dtype=dtype
+                ),
+                "targets": torch.tensor([1.5, 2.5, 3.5, 4.5, 5.5], device=self.device, dtype=dtype),
+                "mse": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 5,
             }
         )
         # Test 4: negative_values
         tests.append(
             {
-                "predictions": torch.tensor([-2.5, -1.0, 0.0, 1.5], device="cuda", dtype=dtype),
-                "targets": torch.tensor([-1.5, -2.0, 0.5, 2.0], device="cuda", dtype=dtype),
-                "mse": torch.empty(1, device="cuda", dtype=dtype),
+                "predictions": torch.tensor(
+                    [-2.5, -1.0, 0.0, 1.5], device=self.device, dtype=dtype
+                ),
+                "targets": torch.tensor([-1.5, -2.0, 0.5, 2.0], device=self.device, dtype=dtype),
+                "mse": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
         # Test 5: large_difference
         tests.append(
             {
-                "predictions": torch.tensor([100.0, 200.0, 300.0], device="cuda", dtype=dtype),
-                "targets": torch.tensor([150.0, 250.0, 350.0], device="cuda", dtype=dtype),
-                "mse": torch.empty(1, device="cuda", dtype=dtype),
+                "predictions": torch.tensor([100.0, 200.0, 300.0], device=self.device, dtype=dtype),
+                "targets": torch.tensor([150.0, 250.0, 350.0], device=self.device, dtype=dtype),
+                "mse": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 3,
             }
         )
         # Test 6: medium_size
         N = 1024
-        predictions = torch.empty(N, device="cuda", dtype=dtype).uniform_(-10.0, 10.0)
-        targets = torch.empty(N, device="cuda", dtype=dtype).uniform_(-10.0, 10.0)
-        mse = torch.empty(1, device="cuda", dtype=dtype)
+        predictions = torch.empty(N, device=self.device, dtype=dtype).uniform_(-10.0, 10.0)
+        targets = torch.empty(N, device=self.device, dtype=dtype).uniform_(-10.0, 10.0)
+        mse = torch.empty(1, device=self.device, dtype=dtype)
         tests.append({"predictions": predictions, "targets": targets, "mse": mse, "N": N})
         # Test 7: large_size
         N = 10000
-        predictions = torch.empty(N, device="cuda", dtype=dtype).uniform_(-100.0, 100.0)
-        targets = torch.empty(N, device="cuda", dtype=dtype).uniform_(-100.0, 100.0)
-        mse = torch.empty(1, device="cuda", dtype=dtype)
+        predictions = torch.empty(N, device=self.device, dtype=dtype).uniform_(-100.0, 100.0)
+        targets = torch.empty(N, device=self.device, dtype=dtype).uniform_(-100.0, 100.0)
+        mse = torch.empty(1, device=self.device, dtype=dtype)
         tests.append({"predictions": predictions, "targets": targets, "mse": mse, "N": N})
         return tests
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 50000000
-        predictions = torch.empty(N, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0)
-        targets = torch.empty(N, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0)
-        mse = torch.empty(1, device="cuda", dtype=dtype)
+        predictions = torch.empty(N, device=self.device, dtype=dtype).uniform_(-1000.0, 1000.0)
+        targets = torch.empty(N, device=self.device, dtype=dtype).uniform_(-1000.0, 1000.0)
+        mse = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "predictions": predictions,
             "targets": targets,

--- a/challenges/medium/28_gaussian_blur/challenge.py
+++ b/challenges/medium/28_gaussian_blur/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Gaussian Blur", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Gaussian Blur"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -71,15 +72,15 @@ class Challenge(ChallengeBase):
                 24.0,
                 25.0,
             ],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
         kernel = torch.tensor(
             [0.0625, 0.125, 0.0625, 0.125, 0.25, 0.125, 0.0625, 0.125, 0.0625],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        output = torch.empty(input_rows * input_cols, device="cuda", dtype=dtype)
+        output = torch.empty(input_rows * input_cols, device=self.device, dtype=dtype)
         return {
             "input": input,
             "kernel": kernel,
@@ -92,7 +93,7 @@ class Challenge(ChallengeBase):
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         tests = []
 
         # basic_example
@@ -186,13 +187,13 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         input_rows, input_cols = 512, 512
         kernel_rows, kernel_cols = 7, 7
-        input = torch.empty(input_rows * input_cols, device="cuda", dtype=dtype).uniform_(
+        input = torch.empty(input_rows * input_cols, device=self.device, dtype=dtype).uniform_(
             0.0, 255.0
         )
-        kernel = torch.empty(kernel_rows * kernel_cols, device="cuda", dtype=dtype).uniform_(
+        kernel = torch.empty(kernel_rows * kernel_cols, device=self.device, dtype=dtype).uniform_(
             0.0001, 0.02
         )
-        output = torch.empty(input_rows * input_cols, device="cuda", dtype=dtype)
+        output = torch.empty(input_rows * input_cols, device=self.device, dtype=dtype)
         return {
             "input": input,
             "kernel": kernel,

--- a/challenges/medium/29_top_k_selection/challenge.py
+++ b/challenges/medium/29_top_k_selection/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Top K Selection", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Top K Selection"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int, k: int):
         assert input.shape == (N,)
@@ -29,8 +30,8 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        input = torch.tensor([1.0, 5.0, 3.0, 2.0, 4.0], device="cuda", dtype=dtype)
-        output = torch.empty(3, device="cuda", dtype=dtype)
+        input = torch.tensor([1.0, 5.0, 3.0, 2.0, 4.0], device=self.device, dtype=dtype)
+        output = torch.empty(3, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,
@@ -44,8 +45,8 @@ class Challenge(ChallengeBase):
         # basic_example
         tests.append(
             {
-                "input": torch.tensor([1.0, 5.0, 3.0, 2.0, 4.0], device="cuda", dtype=dtype),
-                "output": torch.empty(3, device="cuda", dtype=dtype),
+                "input": torch.tensor([1.0, 5.0, 3.0, 2.0, 4.0], device=self.device, dtype=dtype),
+                "output": torch.empty(3, device=self.device, dtype=dtype),
                 "N": 5,
                 "k": 3,
             }
@@ -54,9 +55,9 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "input": torch.tensor(
-                    [-2.0, -1.0, -3.0, -4.0, -5.0, -6.0], device="cuda", dtype=dtype
+                    [-2.0, -1.0, -3.0, -4.0, -5.0, -6.0], device=self.device, dtype=dtype
                 ),
-                "output": torch.empty(2, device="cuda", dtype=dtype),
+                "output": torch.empty(2, device=self.device, dtype=dtype),
                 "N": 6,
                 "k": 2,
             }
@@ -64,8 +65,8 @@ class Challenge(ChallengeBase):
         # all_equal
         tests.append(
             {
-                "input": torch.tensor([7.0, 7.0, 7.0, 7.0], device="cuda", dtype=dtype),
-                "output": torch.empty(3, device="cuda", dtype=dtype),
+                "input": torch.tensor([7.0, 7.0, 7.0, 7.0], device=self.device, dtype=dtype),
+                "output": torch.empty(3, device=self.device, dtype=dtype),
                 "N": 4,
                 "k": 3,
             }
@@ -73,8 +74,8 @@ class Challenge(ChallengeBase):
         # single_element
         tests.append(
             {
-                "input": torch.tensor([42.0], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([42.0], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1,
                 "k": 1,
             }
@@ -82,8 +83,8 @@ class Challenge(ChallengeBase):
         # reverse_sorted
         tests.append(
             {
-                "input": torch.tensor([5.0, 4.0, 3.0, 2.0, 1.0], device="cuda", dtype=dtype),
-                "output": torch.empty(2, device="cuda", dtype=dtype),
+                "input": torch.tensor([5.0, 4.0, 3.0, 2.0, 1.0], device=self.device, dtype=dtype),
+                "output": torch.empty(2, device=self.device, dtype=dtype),
                 "N": 5,
                 "k": 2,
             }
@@ -92,8 +93,8 @@ class Challenge(ChallengeBase):
         N, k = 1000, 10
         tests.append(
             {
-                "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0),
-                "output": torch.empty(k, device="cuda", dtype=dtype),
+                "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-1000.0, 1000.0),
+                "output": torch.empty(k, device=self.device, dtype=dtype),
                 "N": N,
                 "k": k,
             }
@@ -105,8 +106,8 @@ class Challenge(ChallengeBase):
         N = 50000000
         k = 100
         return {
-            "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-1e6, 1e6),
-            "output": torch.empty(k, device="cuda", dtype=dtype),
+            "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-1e6, 1e6),
+            "output": torch.empty(k, device=self.device, dtype=dtype),
             "N": N,
             "k": k,
         }

--- a/challenges/medium/30_batched_matrix_multiplication/challenge.py
+++ b/challenges/medium/30_batched_matrix_multiplication/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Batched Matrix Multiplication",
-            atol=1e-5,
-            rtol=1e-5,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Batched Matrix Multiplication"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self, A: torch.Tensor, B: torch.Tensor, C: torch.Tensor, BATCH: int, M: int, N: int, K: int
@@ -39,20 +36,20 @@ class Challenge(ChallengeBase):
         BATCH, M, K, N = 2, 2, 3, 2
         A = torch.tensor(
             [[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
         B = torch.tensor(
             [[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], [[6.0, 5.0], [4.0, 3.0], [2.0, 1.0]]],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        C = torch.empty(BATCH, M, N, device="cuda", dtype=dtype)
+        C = torch.empty(BATCH, M, N, device=self.device, dtype=dtype)
         return {"A": A, "B": B, "C": C, "BATCH": BATCH, "M": M, "N": N, "K": K}
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         tests = []
 
         # 1. basic_example
@@ -108,11 +105,11 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         BATCH, M, N, K = 32, 256, 256, 256  # Match speed_test.json
-        A = torch.empty(BATCH, M, K, device="cuda", dtype=dtype).uniform_(
+        A = torch.empty(BATCH, M, K, device=self.device, dtype=dtype).uniform_(
             -10.0, 10.0
         )  # Match range
-        B = torch.empty(BATCH, K, N, device="cuda", dtype=dtype).uniform_(
+        B = torch.empty(BATCH, K, N, device=self.device, dtype=dtype).uniform_(
             -10.0, 10.0
         )  # Match range
-        C = torch.empty(BATCH, M, N, device="cuda", dtype=dtype)
+        C = torch.empty(BATCH, M, N, device=self.device, dtype=dtype)
         return {"A": A, "B": B, "C": C, "BATCH": BATCH, "M": M, "N": N, "K": K}

--- a/challenges/medium/32_int8_quantized_matmul/challenge.py
+++ b/challenges/medium/32_int8_quantized_matmul/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="INT8 Quantized MatMul", atol=0, rtol=0, num_gpus=1, access_tier="free"
-        )
+    name = "INT8 Quantized MatMul"
+    atol = 0
+    rtol = 0
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -54,7 +55,7 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.int8
-        device = "cuda"
+        device = self.device
         A = torch.tensor([[1, 2], [3, 4]], dtype=dtype, device=device).flatten()
         B = torch.tensor([[5, 6], [7, 8]], dtype=dtype, device=device).flatten()
         C = torch.tensor([[0, 0], [0, 0]], dtype=dtype, device=device).flatten()
@@ -76,7 +77,7 @@ class Challenge(ChallengeBase):
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
         dtype = torch.int8
-        device = "cuda"
+        device = self.device
         tests = []
 
         # 1. 4x4x4_zero_zp
@@ -188,7 +189,7 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.int8
-        device = "cuda"
+        device = self.device
         shape_A = (8192, 2048)
         shape_B = (2048, 4096)
         shape_C = (8192, 4096)

--- a/challenges/medium/33_ordinary_least_squares/challenge.py
+++ b/challenges/medium/33_ordinary_least_squares/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Ordinary Least Squares", atol=1e-02, rtol=1e-02, num_gpus=1, access_tier="free"
-        )
+    name = "Ordinary Least Squares"
+    atol = 0.01
+    rtol = 0.01
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self, X: torch.Tensor, y: torch.Tensor, beta: torch.Tensor, n_samples: int, n_features: int
@@ -67,10 +68,10 @@ class Challenge(ChallengeBase):
                 [-0.46, -0.47, 0.54],
             ],
             dtype=dtype,
-            device="cuda",
+            device=self.device,
         )
-        y = torch.tensor([83.01, 93.4, 47.33, -62.22, 13.06], dtype=dtype, device="cuda")
-        beta = torch.empty(n_features, dtype=dtype, device="cuda")
+        y = torch.tensor([83.01, 93.4, 47.33, -62.22, 13.06], dtype=dtype, device=self.device)
+        beta = torch.empty(n_features, dtype=dtype, device=self.device)
         return {
             "X": X.flatten(),
             "y": y,
@@ -81,7 +82,7 @@ class Challenge(ChallengeBase):
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         tests = []
 
         # Test 1: simple_1d
@@ -313,7 +314,7 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         n_samples = 32
         n_features = 32
         X = torch.eye(n_samples, dtype=dtype, device=device)

--- a/challenges/medium/34_logistic_regression/challenge.py
+++ b/challenges/medium/34_logistic_regression/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Logistic Regression", atol=1e-02, rtol=1e-02, num_gpus=1, access_tier="free"
-        )
+    name = "Logistic Regression"
+    atol = 0.01
+    rtol = 0.01
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self, X: torch.Tensor, y: torch.Tensor, beta: torch.Tensor, n_samples: int, n_features: int
@@ -84,11 +85,11 @@ class Challenge(ChallengeBase):
                 [-1.5, -2.5],
                 [-3.0, -3.0],
             ],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        y = torch.tensor([1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0], device="cuda", dtype=dtype)
-        beta = torch.zeros(2, device="cuda", dtype=dtype)
+        y = torch.tensor([1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0], device=self.device, dtype=dtype)
+        beta = torch.zeros(2, device=self.device, dtype=dtype)
         return {
             "X": X,
             "y": y,
@@ -112,11 +113,11 @@ class Challenge(ChallengeBase):
                         [0.7620000243186951],
                         [-0.11699999868869781],
                     ],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "y": torch.tensor([1.0, 1.0, 0.0, 0.0, 0.0], device="cuda", dtype=dtype),
-                "beta": torch.zeros(1, device="cuda", dtype=dtype),
+                "y": torch.tensor([1.0, 1.0, 0.0, 0.0, 0.0], device=self.device, dtype=dtype),
+                "beta": torch.zeros(1, device=self.device, dtype=dtype),
                 "n_samples": 5,
                 "n_features": 1,
             }
@@ -134,11 +135,11 @@ class Challenge(ChallengeBase):
                         [0.6309999823570251, -0.2199999988079071],
                         [-0.17299999296665192, 0.2280000001192093],
                     ],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "y": torch.tensor([0.0, 0.0, 1.0, 0.0, 0.0, 0.0], device="cuda", dtype=dtype),
-                "beta": torch.zeros(2, device="cuda", dtype=dtype),
+                "y": torch.tensor([0.0, 0.0, 1.0, 0.0, 0.0, 0.0], device=self.device, dtype=dtype),
+                "beta": torch.zeros(2, device=self.device, dtype=dtype),
                 "n_samples": 6,
                 "n_features": 2,
             }
@@ -153,11 +154,11 @@ class Challenge(ChallengeBase):
                         [-0.8019999861717224, -0.23399999737739563, -0.8579999804496765],
                         [0.9290000200271606, 0.04399999976158142, 0.4740000069141388],
                     ],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "y": torch.tensor([1.0, 0.0, 1.0], device="cuda", dtype=dtype),
-                "beta": torch.zeros(3, device="cuda", dtype=dtype),
+                "y": torch.tensor([1.0, 0.0, 1.0], device=self.device, dtype=dtype),
+                "beta": torch.zeros(3, device=self.device, dtype=dtype),
                 "n_samples": 3,
                 "n_features": 3,
             }
@@ -177,13 +178,13 @@ class Challenge(ChallengeBase):
                         [-0.061000000685453415, -0.7730000019073486, -0.30300000309944153],
                         [-0.6970000267028809, -0.3140000104904175, 0.16599999368190765],
                     ],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "y": torch.tensor(
-                    [1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0], device="cuda", dtype=dtype
+                    [1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0], device=self.device, dtype=dtype
                 ),
-                "beta": torch.zeros(3, device="cuda", dtype=dtype),
+                "beta": torch.zeros(3, device=self.device, dtype=dtype),
                 "n_samples": 8,
                 "n_features": 3,
             }
@@ -205,13 +206,15 @@ class Challenge(ChallengeBase):
                         [-0.01600000075995922, -0.7639999985694885, -0.06199999898672104],
                         [-0.13099999725818634, 0.49799999594688416, 0.1589999943971634],
                     ],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "y": torch.tensor(
-                    [1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0], device="cuda", dtype=dtype
+                    [1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0],
+                    device=self.device,
+                    dtype=dtype,
                 ),
-                "beta": torch.zeros(3, device="cuda", dtype=dtype),
+                "beta": torch.zeros(3, device=self.device, dtype=dtype),
                 "n_samples": 10,
                 "n_features": 3,
             }
@@ -221,7 +224,7 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
 
         X = torch.eye(8, device=device, dtype=dtype).repeat(2, 1)
         y = torch.tensor(

--- a/challenges/medium/35_monte_carlo_integration/challenge.py
+++ b/challenges/medium/35_monte_carlo_integration/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Monte Carlo Integration", atol=1e-02, rtol=1e-02, num_gpus=1, access_tier="free"
-        )
+    name = "Monte Carlo Integration"
+    atol = 0.01
+    rtol = 0.01
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self, y_samples: torch.Tensor, result: torch.Tensor, a: float, b: float, n_samples: int
@@ -38,9 +39,9 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         y_samples = torch.tensor(
-            [0.0625, 0.25, 0.5625, 1.0, 1.5625, 2.25, 3.0625, 4.0], device="cuda", dtype=dtype
+            [0.0625, 0.25, 0.5625, 1.0, 1.5625, 2.25, 3.0625, 4.0], device=self.device, dtype=dtype
         )
-        result = torch.zeros(1, device="cuda", dtype=dtype)
+        result = torch.zeros(1, device=self.device, dtype=dtype)
         return {
             "y_samples": y_samples,
             "result": result,
@@ -65,8 +66,8 @@ class Challenge(ChallengeBase):
             n_samples = len(y_vals)
             test_cases.append(
                 {
-                    "y_samples": torch.tensor(y_vals, device="cuda", dtype=dtype),
-                    "result": torch.zeros(1, device="cuda", dtype=dtype),
+                    "y_samples": torch.tensor(y_vals, device=self.device, dtype=dtype),
+                    "result": torch.zeros(1, device=self.device, dtype=dtype),
                     "a": a,
                     "b": b,
                     "n_samples": n_samples,
@@ -82,10 +83,10 @@ class Challenge(ChallengeBase):
         ]:
             test_cases.append(
                 {
-                    "y_samples": torch.empty(n_samples, device="cuda", dtype=dtype).uniform_(
+                    "y_samples": torch.empty(n_samples, device=self.device, dtype=dtype).uniform_(
                         -10.0, 10.0
                     ),
-                    "result": torch.zeros(1, device="cuda", dtype=dtype),
+                    "result": torch.zeros(1, device=self.device, dtype=dtype),
                     "a": a,
                     "b": b,
                     "n_samples": n_samples,
@@ -100,10 +101,10 @@ class Challenge(ChallengeBase):
         ]:
             test_cases.append(
                 {
-                    "y_samples": torch.empty(n_samples, device="cuda", dtype=dtype).uniform_(
+                    "y_samples": torch.empty(n_samples, device=self.device, dtype=dtype).uniform_(
                         -1.0, 1.0
                     ),
-                    "result": torch.zeros(1, device="cuda", dtype=dtype),
+                    "result": torch.zeros(1, device=self.device, dtype=dtype),
                     "a": a,
                     "b": b,
                     "n_samples": n_samples,
@@ -116,10 +117,10 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         n_samples = 10000000
         return {
-            "y_samples": torch.empty(n_samples, device="cuda", dtype=dtype).uniform_(
+            "y_samples": torch.empty(n_samples, device=self.device, dtype=dtype).uniform_(
                 -1000.0, 1000.0
             ),
-            "result": torch.zeros(1, device="cuda", dtype=dtype),
+            "result": torch.zeros(1, device=self.device, dtype=dtype),
             "a": -10.0,
             "b": 10.0,
             "n_samples": n_samples,

--- a/challenges/medium/37_matrix_power/challenge.py
+++ b/challenges/medium/37_matrix_power/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Matrix Power", atol=1e-04, rtol=1e-04, num_gpus=1, access_tier="free"
-        )
+    name = "Matrix Power"
+    atol = 0.0001
+    rtol = 0.0001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int, P: int):
         """
@@ -37,8 +38,10 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 2
         P = 3
-        input_data = torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="cuda", dtype=dtype).flatten()
-        output_data = torch.zeros((2, 2), device="cuda", dtype=dtype).flatten()
+        input_data = torch.tensor(
+            [[1.0, 2.0], [3.0, 4.0]], device=self.device, dtype=dtype
+        ).flatten()
+        output_data = torch.zeros((2, 2), device=self.device, dtype=dtype).flatten()
 
         return {
             "input": input_data,
@@ -55,9 +58,9 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "input": torch.tensor(
-                    [[1.0, 2.0], [3.0, 4.0]], device="cuda", dtype=dtype
+                    [[1.0, 2.0], [3.0, 4.0]], device=self.device, dtype=dtype
                 ).flatten(),
-                "output": torch.zeros((2, 2), device="cuda", dtype=dtype).flatten(),
+                "output": torch.zeros((2, 2), device=self.device, dtype=dtype).flatten(),
                 "N": 2,
                 "P": 3,
             }
@@ -66,8 +69,8 @@ class Challenge(ChallengeBase):
         # Test case 2: identity 3x3 power 5
         test_cases.append(
             {
-                "input": torch.eye(3, device="cuda", dtype=dtype).flatten(),
-                "output": torch.zeros((3, 3), device="cuda", dtype=dtype).flatten(),
+                "input": torch.eye(3, device=self.device, dtype=dtype).flatten(),
+                "output": torch.zeros((3, 3), device=self.device, dtype=dtype).flatten(),
                 "N": 3,
                 "P": 5,
             }
@@ -76,10 +79,10 @@ class Challenge(ChallengeBase):
         # Test case 3: random 5x5 power 2
         test_cases.append(
             {
-                "input": torch.empty((5, 5), device="cuda", dtype=dtype)
+                "input": torch.empty((5, 5), device=self.device, dtype=dtype)
                 .uniform_(-5.0, 5.0)
                 .flatten(),
-                "output": torch.zeros((5, 5), device="cuda", dtype=dtype).flatten(),
+                "output": torch.zeros((5, 5), device=self.device, dtype=dtype).flatten(),
                 "N": 5,
                 "P": 2,
             }
@@ -88,10 +91,10 @@ class Challenge(ChallengeBase):
         # Test case 4: random 16x16 power 3
         test_cases.append(
             {
-                "input": torch.empty((16, 16), device="cuda", dtype=dtype)
+                "input": torch.empty((16, 16), device=self.device, dtype=dtype)
                 .uniform_(-1.0, 1.0)
                 .flatten(),
-                "output": torch.zeros((16, 16), device="cuda", dtype=dtype).flatten(),
+                "output": torch.zeros((16, 16), device=self.device, dtype=dtype).flatten(),
                 "N": 16,
                 "P": 3,
             }
@@ -100,10 +103,10 @@ class Challenge(ChallengeBase):
         # Test case 5: random 8x8 power 4
         test_cases.append(
             {
-                "input": torch.empty((8, 8), device="cuda", dtype=dtype)
+                "input": torch.empty((8, 8), device=self.device, dtype=dtype)
                 .uniform_(-10.0, 10.0)
                 .flatten(),
-                "output": torch.zeros((8, 8), device="cuda", dtype=dtype).flatten(),
+                "output": torch.zeros((8, 8), device=self.device, dtype=dtype).flatten(),
                 "N": 8,
                 "P": 4,
             }
@@ -112,10 +115,10 @@ class Challenge(ChallengeBase):
         # Test case 6: random 10x10 power 1
         test_cases.append(
             {
-                "input": torch.empty((10, 10), device="cuda", dtype=dtype)
+                "input": torch.empty((10, 10), device=self.device, dtype=dtype)
                 .uniform_(-2.0, 2.0)
                 .flatten(),
-                "output": torch.zeros((10, 10), device="cuda", dtype=dtype).flatten(),
+                "output": torch.zeros((10, 10), device=self.device, dtype=dtype).flatten(),
                 "N": 10,
                 "P": 1,
             }
@@ -128,10 +131,10 @@ class Challenge(ChallengeBase):
         N = 512
         P = 3
         return {
-            "input": torch.empty((N, N), device="cuda", dtype=dtype)
+            "input": torch.empty((N, N), device=self.device, dtype=dtype)
             .uniform_(-10.0, 10.0)
             .flatten(),
-            "output": torch.zeros((N, N), device="cuda", dtype=dtype).flatten(),
+            "output": torch.zeros((N, N), device=self.device, dtype=dtype).flatten(),
             "N": N,
             "P": P,
         }

--- a/challenges/medium/38_nearest_neighbor/challenge.py
+++ b/challenges/medium/38_nearest_neighbor/challenge.py
@@ -6,8 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(name="Nearest Neighbor", atol=0, rtol=0, num_gpus=1, access_tier="free")
+    name = "Nearest Neighbor"
+    atol = 0
+    rtol = 0
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, points: torch.Tensor, indices: torch.Tensor, N: int):
         """
@@ -55,10 +58,10 @@ class Challenge(ChallengeBase):
         # Example: points = [(0,0,0), (1,0,0), (5,5,5)]
         points_data = torch.tensor(
             [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 5.0, 5.0, 5.0],  # point 0  # point 1  # point 2
-            device="cuda",
+            device=self.device,
             dtype=dtype_float,
         )
-        indices_data = torch.full((N,), -1, device="cuda", dtype=dtype_int)
+        indices_data = torch.full((N,), -1, device=self.device, dtype=dtype_int)
 
         return {
             "points": points_data,
@@ -76,10 +79,10 @@ class Challenge(ChallengeBase):
             {
                 "points": torch.tensor(
                     [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 5.0, 5.0, 5.0],  # point 0  # point 1  # point 2
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype_float,
                 ),
-                "indices": torch.full((3,), -1, device="cuda", dtype=dtype_int),
+                "indices": torch.full((3,), -1, device=self.device, dtype=dtype_int),
                 "N": 3,
             }
         )
@@ -89,10 +92,10 @@ class Challenge(ChallengeBase):
             {
                 "points": torch.tensor(
                     [0.0, 0.0, 0.0, 3.0, 4.0, 0.0],  # point 0  # point 1
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype_float,
                 ),
-                "indices": torch.full((2,), -1, device="cuda", dtype=dtype_int),
+                "indices": torch.full((2,), -1, device=self.device, dtype=dtype_int),
                 "N": 2,
             }
         )
@@ -115,10 +118,10 @@ class Challenge(ChallengeBase):
                         1.0,
                         0.0,
                     ],  # point 3
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype_float,
                 ),
-                "indices": torch.full((4,), -1, device="cuda", dtype=dtype_int),
+                "indices": torch.full((4,), -1, device=self.device, dtype=dtype_int),
                 "N": 4,
             }
         )
@@ -141,10 +144,10 @@ class Challenge(ChallengeBase):
                         2.0,
                         2.0,
                     ],  # point 3
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype_float,
                 ),
-                "indices": torch.full((4,), -1, device="cuda", dtype=dtype_int),
+                "indices": torch.full((4,), -1, device=self.device, dtype=dtype_int),
                 "N": 4,
             }
         )
@@ -170,10 +173,10 @@ class Challenge(ChallengeBase):
                         0.0,
                         0.0,
                     ],  # point 4
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype_float,
                 ),
-                "indices": torch.full((5,), -1, device="cuda", dtype=dtype_int),
+                "indices": torch.full((5,), -1, device=self.device, dtype=dtype_int),
                 "N": 5,
             }
         )
@@ -182,10 +185,10 @@ class Challenge(ChallengeBase):
         torch.manual_seed(42)
         test_cases.append(
             {
-                "points": torch.empty((100, 3), device="cuda", dtype=dtype_float)
+                "points": torch.empty((100, 3), device=self.device, dtype=dtype_float)
                 .uniform_(-100.0, 100.0)
                 .flatten(),
-                "indices": torch.full((100,), -1, device="cuda", dtype=dtype_int),
+                "indices": torch.full((100,), -1, device=self.device, dtype=dtype_int),
                 "N": 100,
             }
         )
@@ -194,10 +197,10 @@ class Challenge(ChallengeBase):
         torch.manual_seed(123)
         test_cases.append(
             {
-                "points": torch.empty((250, 3), device="cuda", dtype=dtype_float)
+                "points": torch.empty((250, 3), device=self.device, dtype=dtype_float)
                 .uniform_(-1000.0, 1000.0)
                 .flatten(),
-                "indices": torch.full((250,), -1, device="cuda", dtype=dtype_int),
+                "indices": torch.full((250,), -1, device=self.device, dtype=dtype_int),
                 "N": 250,
             }
         )
@@ -210,9 +213,9 @@ class Challenge(ChallengeBase):
         N = 10000
 
         return {
-            "points": torch.empty((N, 3), device="cuda", dtype=dtype_float)
+            "points": torch.empty((N, 3), device=self.device, dtype=dtype_float)
             .uniform_(-1000.0, 1000.0)
             .flatten(),
-            "indices": torch.full((N,), -1, device="cuda", dtype=dtype_int),
+            "indices": torch.full((N,), -1, device=self.device, dtype=dtype_int),
             "N": N,
         }

--- a/challenges/medium/40_batch_normalization/challenge.py
+++ b/challenges/medium/40_batch_normalization/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Batch Normalization", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Batch Normalization"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -50,10 +51,10 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N, C = 3, 2
-        input = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], device="cuda", dtype=dtype)
-        gamma = torch.tensor([1.0, 1.0], device="cuda", dtype=dtype)
-        beta = torch.tensor([0.0, 0.0], device="cuda", dtype=dtype)
-        output = torch.empty((N, C), device="cuda", dtype=dtype)
+        input = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], device=self.device, dtype=dtype)
+        gamma = torch.tensor([1.0, 1.0], device=self.device, dtype=dtype)
+        beta = torch.tensor([0.0, 0.0], device=self.device, dtype=dtype)
+        output = torch.empty((N, C), device=self.device, dtype=dtype)
         eps = 1e-5
         return {
             "input": input,
@@ -74,11 +75,11 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "input": torch.tensor(
-                    [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], device="cuda", dtype=dtype
+                    [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], device=self.device, dtype=dtype
                 ),
-                "gamma": torch.tensor([1.0, 1.0], device="cuda", dtype=dtype),
-                "beta": torch.tensor([0.0, 0.0], device="cuda", dtype=dtype),
-                "output": torch.empty((N, C), device="cuda", dtype=dtype),
+                "gamma": torch.tensor([1.0, 1.0], device=self.device, dtype=dtype),
+                "beta": torch.tensor([0.0, 0.0], device=self.device, dtype=dtype),
+                "output": torch.empty((N, C), device=self.device, dtype=dtype),
                 "N": N,
                 "C": C,
                 "eps": 1e-5,
@@ -89,10 +90,10 @@ class Challenge(ChallengeBase):
         N, C = 1, 4
         tests.append(
             {
-                "input": torch.tensor([[1.0, 2.0, 3.0, 4.0]], device="cuda", dtype=dtype),
-                "gamma": torch.tensor([1.0, 1.0, 1.0, 1.0], device="cuda", dtype=dtype),
-                "beta": torch.tensor([0.0, 0.0, 0.0, 0.0], device="cuda", dtype=dtype),
-                "output": torch.empty((N, C), device="cuda", dtype=dtype),
+                "input": torch.tensor([[1.0, 2.0, 3.0, 4.0]], device=self.device, dtype=dtype),
+                "gamma": torch.tensor([1.0, 1.0, 1.0, 1.0], device=self.device, dtype=dtype),
+                "beta": torch.tensor([0.0, 0.0, 0.0, 0.0], device=self.device, dtype=dtype),
+                "output": torch.empty((N, C), device=self.device, dtype=dtype),
                 "N": N,
                 "C": C,
                 "eps": 1e-5,
@@ -103,10 +104,10 @@ class Challenge(ChallengeBase):
         N, C = 4, 3
         tests.append(
             {
-                "input": torch.zeros((N, C), device="cuda", dtype=dtype),
-                "gamma": torch.ones(C, device="cuda", dtype=dtype),
-                "beta": torch.zeros(C, device="cuda", dtype=dtype),
-                "output": torch.empty((N, C), device="cuda", dtype=dtype),
+                "input": torch.zeros((N, C), device=self.device, dtype=dtype),
+                "gamma": torch.ones(C, device=self.device, dtype=dtype),
+                "beta": torch.zeros(C, device=self.device, dtype=dtype),
+                "output": torch.empty((N, C), device=self.device, dtype=dtype),
                 "N": N,
                 "C": C,
                 "eps": 1e-5,
@@ -118,11 +119,11 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "input": torch.tensor(
-                    [[-1.0, -2.0, -3.0], [-4.0, -5.0, -6.0]], device="cuda", dtype=dtype
+                    [[-1.0, -2.0, -3.0], [-4.0, -5.0, -6.0]], device=self.device, dtype=dtype
                 ),
-                "gamma": torch.tensor([1.0, 1.0, 1.0], device="cuda", dtype=dtype),
-                "beta": torch.tensor([0.0, 0.0, 0.0], device="cuda", dtype=dtype),
-                "output": torch.empty((N, C), device="cuda", dtype=dtype),
+                "gamma": torch.tensor([1.0, 1.0, 1.0], device=self.device, dtype=dtype),
+                "beta": torch.tensor([0.0, 0.0, 0.0], device=self.device, dtype=dtype),
+                "output": torch.empty((N, C), device=self.device, dtype=dtype),
                 "N": N,
                 "C": C,
                 "eps": 1e-5,
@@ -133,10 +134,10 @@ class Challenge(ChallengeBase):
         N, C = 2, 2
         tests.append(
             {
-                "input": torch.tensor([[0.0, 1.0], [2.0, 3.0]], device="cuda", dtype=dtype),
-                "gamma": torch.tensor([2.0, 0.5], device="cuda", dtype=dtype),
-                "beta": torch.tensor([1.0, -1.0], device="cuda", dtype=dtype),
-                "output": torch.empty((N, C), device="cuda", dtype=dtype),
+                "input": torch.tensor([[0.0, 1.0], [2.0, 3.0]], device=self.device, dtype=dtype),
+                "gamma": torch.tensor([2.0, 0.5], device=self.device, dtype=dtype),
+                "beta": torch.tensor([1.0, -1.0], device=self.device, dtype=dtype),
+                "output": torch.empty((N, C), device=self.device, dtype=dtype),
                 "N": N,
                 "C": C,
                 "eps": 1e-5,
@@ -147,10 +148,10 @@ class Challenge(ChallengeBase):
         N, C = 5, 3
         tests.append(
             {
-                "input": torch.empty((N, C), device="cuda", dtype=dtype).uniform_(-50.0, 50.0),
-                "gamma": torch.empty(C, device="cuda", dtype=dtype).uniform_(0.5, 2.0),
-                "beta": torch.empty(C, device="cuda", dtype=dtype).uniform_(-5.0, 5.0),
-                "output": torch.empty((N, C), device="cuda", dtype=dtype),
+                "input": torch.empty((N, C), device=self.device, dtype=dtype).uniform_(-50.0, 50.0),
+                "gamma": torch.empty(C, device=self.device, dtype=dtype).uniform_(0.5, 2.0),
+                "beta": torch.empty(C, device=self.device, dtype=dtype).uniform_(-5.0, 5.0),
+                "output": torch.empty((N, C), device=self.device, dtype=dtype),
                 "N": N,
                 "C": C,
                 "eps": 1e-5,
@@ -161,10 +162,10 @@ class Challenge(ChallengeBase):
         N, C = 64, 32
         tests.append(
             {
-                "input": torch.empty((N, C), device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-                "gamma": torch.empty(C, device="cuda", dtype=dtype).uniform_(0.5, 2.0),
-                "beta": torch.empty(C, device="cuda", dtype=dtype).uniform_(-2.0, 2.0),
-                "output": torch.empty((N, C), device="cuda", dtype=dtype),
+                "input": torch.empty((N, C), device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
+                "gamma": torch.empty(C, device=self.device, dtype=dtype).uniform_(0.5, 2.0),
+                "beta": torch.empty(C, device=self.device, dtype=dtype).uniform_(-2.0, 2.0),
+                "output": torch.empty((N, C), device=self.device, dtype=dtype),
                 "N": N,
                 "C": C,
                 "eps": 1e-5,
@@ -175,10 +176,10 @@ class Challenge(ChallengeBase):
         N, C = 100, 1
         tests.append(
             {
-                "input": torch.empty((N, C), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "gamma": torch.tensor([1.5], device="cuda", dtype=dtype),
-                "beta": torch.tensor([0.5], device="cuda", dtype=dtype),
-                "output": torch.empty((N, C), device="cuda", dtype=dtype),
+                "input": torch.empty((N, C), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "gamma": torch.tensor([1.5], device=self.device, dtype=dtype),
+                "beta": torch.tensor([0.5], device=self.device, dtype=dtype),
+                "output": torch.empty((N, C), device=self.device, dtype=dtype),
                 "N": N,
                 "C": C,
                 "eps": 1e-5,
@@ -187,17 +188,17 @@ class Challenge(ChallengeBase):
 
         # high_variance
         N, C = 10, 5
-        input_data = torch.empty((N, C), device="cuda", dtype=dtype)
+        input_data = torch.empty((N, C), device=self.device, dtype=dtype)
         for i in range(C):
             input_data[:, i] = torch.linspace(
-                -100 + i * 10, 100 - i * 10, N, device="cuda", dtype=dtype
+                -100 + i * 10, 100 - i * 10, N, device=self.device, dtype=dtype
             )
         tests.append(
             {
                 "input": input_data,
-                "gamma": torch.ones(C, device="cuda", dtype=dtype),
-                "beta": torch.zeros(C, device="cuda", dtype=dtype),
-                "output": torch.empty((N, C), device="cuda", dtype=dtype),
+                "gamma": torch.ones(C, device=self.device, dtype=dtype),
+                "beta": torch.zeros(C, device=self.device, dtype=dtype),
+                "output": torch.empty((N, C), device=self.device, dtype=dtype),
                 "N": N,
                 "C": C,
                 "eps": 1e-5,
@@ -210,10 +211,10 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N, C = 5000, 512
         return {
-            "input": torch.empty((N, C), device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-            "gamma": torch.empty(C, device="cuda", dtype=dtype).uniform_(0.5, 2.0),
-            "beta": torch.empty(C, device="cuda", dtype=dtype).uniform_(-2.0, 2.0),
-            "output": torch.empty((N, C), device="cuda", dtype=dtype),
+            "input": torch.empty((N, C), device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
+            "gamma": torch.empty(C, device=self.device, dtype=dtype).uniform_(0.5, 2.0),
+            "beta": torch.empty(C, device=self.device, dtype=dtype).uniform_(-2.0, 2.0),
+            "output": torch.empty((N, C), device=self.device, dtype=dtype),
             "N": N,
             "C": C,
             "eps": 1e-5,

--- a/challenges/medium/42_2d_max_pooling/challenge.py
+++ b/challenges/medium/42_2d_max_pooling/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="2D Max Pooling", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "2D Max Pooling"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -53,13 +54,13 @@ class Challenge(ChallengeBase):
 
         # Create input tensor: [[[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]]
         input_tensor = torch.tensor(
-            [[[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]]], device="cuda", dtype=dtype
+            [[[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]]], device=self.device, dtype=dtype
         )
 
         # Calculate output dimensions
         H_out = (H + 2 * padding - kernel_size) // stride + 1
         W_out = (W + 2 * padding - kernel_size) // stride + 1
-        output_tensor = torch.empty(N * C * H_out * W_out, device="cuda", dtype=dtype)
+        output_tensor = torch.empty(N * C * H_out * W_out, device=self.device, dtype=dtype)
 
         return {
             "input": input_tensor.flatten(),
@@ -98,10 +99,10 @@ class Challenge(ChallengeBase):
                     ]
                 ]
             ],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        output_tensor = torch.empty(N * C * H_out * W_out, device="cuda", dtype=dtype)
+        output_tensor = torch.empty(N * C * H_out * W_out, device=self.device, dtype=dtype)
 
         test_cases.append(
             {
@@ -123,8 +124,8 @@ class Challenge(ChallengeBase):
         H_out = (H + 2 * padding - kernel_size) // stride + 1
         W_out = (W + 2 * padding - kernel_size) // stride + 1
 
-        input_tensor = torch.randn(N, C, H, W, device="cuda", dtype=dtype)
-        output_tensor = torch.empty(N * C * H_out * W_out, device="cuda", dtype=dtype)
+        input_tensor = torch.randn(N, C, H, W, device=self.device, dtype=dtype)
+        output_tensor = torch.empty(N * C * H_out * W_out, device=self.device, dtype=dtype)
 
         test_cases.append(
             {
@@ -146,8 +147,8 @@ class Challenge(ChallengeBase):
         H_out = (H + 2 * padding - kernel_size) // stride + 1
         W_out = (W + 2 * padding - kernel_size) // stride + 1
 
-        input_tensor = torch.randn(N, C, H, W, device="cuda", dtype=dtype)
-        output_tensor = torch.empty(N * C * H_out * W_out, device="cuda", dtype=dtype)
+        input_tensor = torch.randn(N, C, H, W, device=self.device, dtype=dtype)
+        output_tensor = torch.empty(N * C * H_out * W_out, device=self.device, dtype=dtype)
 
         test_cases.append(
             {
@@ -169,8 +170,8 @@ class Challenge(ChallengeBase):
         H_out = (H + 2 * padding - kernel_size) // stride + 1
         W_out = (W + 2 * padding - kernel_size) // stride + 1
 
-        input_tensor = torch.randn(N, C, H, W, device="cuda", dtype=dtype)
-        output_tensor = torch.empty(N * C * H_out * W_out, device="cuda", dtype=dtype)
+        input_tensor = torch.randn(N, C, H, W, device=self.device, dtype=dtype)
+        output_tensor = torch.empty(N * C * H_out * W_out, device=self.device, dtype=dtype)
 
         test_cases.append(
             {
@@ -192,8 +193,8 @@ class Challenge(ChallengeBase):
         H_out = (H + 2 * padding - kernel_size) // stride + 1
         W_out = (W + 2 * padding - kernel_size) // stride + 1
 
-        input_tensor = torch.tensor([[[[1.0, 2.0], [3.0, 4.0]]]], device="cuda", dtype=dtype)
-        output_tensor = torch.empty(N * C * H_out * W_out, device="cuda", dtype=dtype)
+        input_tensor = torch.tensor([[[[1.0, 2.0], [3.0, 4.0]]]], device=self.device, dtype=dtype)
+        output_tensor = torch.empty(N * C * H_out * W_out, device=self.device, dtype=dtype)
 
         test_cases.append(
             {
@@ -216,9 +217,9 @@ class Challenge(ChallengeBase):
         W_out = (W + 2 * padding - kernel_size) // stride + 1
 
         input_tensor = torch.tensor(
-            [[[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]]], device="cuda", dtype=dtype
+            [[[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]]], device=self.device, dtype=dtype
         )
-        output_tensor = torch.empty(N * C * H_out * W_out, device="cuda", dtype=dtype)
+        output_tensor = torch.empty(N * C * H_out * W_out, device=self.device, dtype=dtype)
 
         test_cases.append(
             {
@@ -251,10 +252,10 @@ class Challenge(ChallengeBase):
                     ]
                 ]
             ],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        output_tensor = torch.empty(N * C * H_out * W_out, device="cuda", dtype=dtype)
+        output_tensor = torch.empty(N * C * H_out * W_out, device=self.device, dtype=dtype)
 
         test_cases.append(
             {
@@ -277,16 +278,18 @@ class Challenge(ChallengeBase):
         W_out = (W + 2 * padding - kernel_size) // stride + 1
 
         # Create structured input with different patterns per channel
-        input_tensor = torch.zeros(N, C, H, W, device="cuda", dtype=dtype)
-        input_tensor[0, 0, :, :] = torch.arange(H * W, device="cuda", dtype=dtype).reshape(H, W)
+        input_tensor = torch.zeros(N, C, H, W, device=self.device, dtype=dtype)
+        input_tensor[0, 0, :, :] = torch.arange(H * W, device=self.device, dtype=dtype).reshape(
+            H, W
+        )
         input_tensor[0, 1, :, :] = (
-            torch.arange(H * W, device="cuda", dtype=dtype).reshape(H, W).flip(0)
+            torch.arange(H * W, device=self.device, dtype=dtype).reshape(H, W).flip(0)
         )
         input_tensor[0, 2, :, :] = (
-            torch.arange(H * W, device="cuda", dtype=dtype).reshape(H, W).flip(1)
+            torch.arange(H * W, device=self.device, dtype=dtype).reshape(H, W).flip(1)
         )
 
-        output_tensor = torch.empty(N * C * H_out * W_out, device="cuda", dtype=dtype)
+        output_tensor = torch.empty(N * C * H_out * W_out, device=self.device, dtype=dtype)
 
         test_cases.append(
             {
@@ -321,10 +324,10 @@ class Challenge(ChallengeBase):
                     ]
                 ]
             ],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        output_tensor = torch.empty(N * C * H_out * W_out, device="cuda", dtype=dtype)
+        output_tensor = torch.empty(N * C * H_out * W_out, device=self.device, dtype=dtype)
 
         test_cases.append(
             {
@@ -346,8 +349,8 @@ class Challenge(ChallengeBase):
         H_out = (H + 2 * padding - kernel_size) // stride + 1
         W_out = (W + 2 * padding - kernel_size) // stride + 1
 
-        input_tensor = torch.randn(N, C, H, W, device="cuda", dtype=dtype)
-        output_tensor = torch.empty(N * C * H_out * W_out, device="cuda", dtype=dtype)
+        input_tensor = torch.randn(N, C, H, W, device=self.device, dtype=dtype)
+        output_tensor = torch.empty(N * C * H_out * W_out, device=self.device, dtype=dtype)
 
         test_cases.append(
             {
@@ -377,8 +380,8 @@ class Challenge(ChallengeBase):
 
         # Use seeded random for reproducible performance tests
         torch.manual_seed(123)
-        input_tensor = torch.randn(N, C, H, W, device="cuda", dtype=dtype)
-        output_tensor = torch.empty(N * C * H_out * W_out, device="cuda", dtype=dtype)
+        input_tensor = torch.randn(N, C, H, W, device=self.device, dtype=dtype)
+        output_tensor = torch.empty(N * C * H_out * W_out, device=self.device, dtype=dtype)
 
         return {
             "input": input_tensor.flatten(),

--- a/challenges/medium/43_count_array_element/challenge.py
+++ b/challenges/medium/43_count_array_element/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Count Array Element", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Count Array Element"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int, K: int):
         # Validate input types and shapes
@@ -32,8 +33,8 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.tensor([1, 2, 3, 4, 1], device="cuda", dtype=dtype)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.tensor([1, 2, 3, 4, 1], device=self.device, dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,
@@ -48,8 +49,8 @@ class Challenge(ChallengeBase):
         # basic_example
         tests.append(
             {
-                "input": torch.tensor([1, 2, 3, 4, 1], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([1, 2, 3, 4, 1], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 5,
                 "K": 1,
             }
@@ -58,8 +59,8 @@ class Challenge(ChallengeBase):
         # all_same_value
         tests.append(
             {
-                "input": torch.tensor([2] * 16, device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([2] * 16, device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 16,
                 "K": 2,
             }
@@ -68,8 +69,8 @@ class Challenge(ChallengeBase):
         # increasing_sequence
         tests.append(
             {
-                "input": torch.randint(1, 5, (32,), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 5, (32,), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 32,
                 "K": 4,
             }
@@ -78,8 +79,8 @@ class Challenge(ChallengeBase):
         # medium_size
         tests.append(
             {
-                "input": torch.randint(1, 10, (1000,), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 10, (1000,), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1000,
                 "K": 5,
             }
@@ -88,8 +89,8 @@ class Challenge(ChallengeBase):
         # large_size
         tests.append(
             {
-                "input": torch.randint(1, 1000, (100000,), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 1000, (100000,), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 100000,
                 "K": 501,
             }
@@ -99,8 +100,8 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.randint(1, 100001, (100000000,), device="cuda", dtype=dtype)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.randint(1, 100001, (100000000,), device=self.device, dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,

--- a/challenges/medium/44_count_2d_array_element/challenge.py
+++ b/challenges/medium/44_count_2d_array_element/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Count 2D Array Element", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Count 2D Array Element"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int, M: int, K: int):
         # Validate input types and shapes
@@ -33,8 +34,8 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.tensor([[1, 2, 3], [4, 5, 1]], device="cuda", dtype=dtype)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.tensor([[1, 2, 3], [4, 5, 1]], device=self.device, dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,
@@ -50,8 +51,8 @@ class Challenge(ChallengeBase):
         # basic_example
         tests.append(
             {
-                "input": torch.tensor([[1, 2, 3], [4, 5, 1]], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([[1, 2, 3], [4, 5, 1]], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 2,
                 "M": 3,
                 "K": 1,
@@ -61,8 +62,8 @@ class Challenge(ChallengeBase):
         # all_same_value
         tests.append(
             {
-                "input": torch.tensor([[2] * 16] * 3, device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([[2] * 16] * 3, device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 3,
                 "M": 16,
                 "K": 2,
@@ -72,8 +73,8 @@ class Challenge(ChallengeBase):
         # increasing_sequence
         tests.append(
             {
-                "input": torch.randint(1, 11, (50, 50), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 11, (50, 50), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 50,
                 "M": 50,
                 "K": 5,
@@ -83,8 +84,8 @@ class Challenge(ChallengeBase):
         # medium_size
         tests.append(
             {
-                "input": torch.randint(1, 101, (100, 100), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 101, (100, 100), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 100,
                 "M": 100,
                 "K": 51,
@@ -94,8 +95,8 @@ class Challenge(ChallengeBase):
         # large_size
         tests.append(
             {
-                "input": torch.randint(1, 11, (1000, 1000), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 11, (1000, 1000), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1000,
                 "M": 1000,
                 "K": 1,
@@ -106,8 +107,8 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.randint(1, 3, (10000, 10000), device="cuda", dtype=dtype)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.randint(1, 3, (10000, 10000), device=self.device, dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,

--- a/challenges/medium/45_count_3d_array_element/challenge.py
+++ b/challenges/medium/45_count_3d_array_element/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Count 3D Array Element", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Count 3D Array Element"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self, input: torch.Tensor, output: torch.Tensor, N: int, M: int, K: int, P: int
@@ -38,9 +39,9 @@ class Challenge(ChallengeBase):
         dtype = torch.int32
 
         input = torch.tensor(
-            [[[1, 2, 3], [4, 5, 1]], [[1, 1, 1], [2, 2, 2]]], device="cuda", dtype=dtype
+            [[[1, 2, 3], [4, 5, 1]], [[1, 1, 1], [2, 2, 2]]], device=self.device, dtype=dtype
         )
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,
@@ -58,9 +59,11 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "input": torch.tensor(
-                    [[[1, 2, 3], [4, 5, 1]], [[1, 1, 1], [2, 2, 2]]], device="cuda", dtype=dtype
+                    [[[1, 2, 3], [4, 5, 1]], [[1, 1, 1], [2, 2, 2]]],
+                    device=self.device,
+                    dtype=dtype,
                 ),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 2,
                 "M": 2,
                 "K": 3,
@@ -71,8 +74,8 @@ class Challenge(ChallengeBase):
         # all_same_value
         tests.append(
             {
-                "input": torch.tensor([[[2] * 16] * 3] * 15, device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([[[2] * 16] * 3] * 15, device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 15,
                 "M": 3,
                 "K": 16,
@@ -83,8 +86,8 @@ class Challenge(ChallengeBase):
         # increasing_sequence
         tests.append(
             {
-                "input": torch.randint(1, 11, (50, 50, 50), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 11, (50, 50, 50), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 50,
                 "M": 50,
                 "K": 50,
@@ -95,8 +98,8 @@ class Challenge(ChallengeBase):
         # medium_size
         tests.append(
             {
-                "input": torch.randint(1, 101, (100, 100, 100), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 101, (100, 100, 100), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 100,
                 "M": 100,
                 "K": 100,
@@ -107,8 +110,8 @@ class Challenge(ChallengeBase):
         # large_size
         tests.append(
             {
-                "input": torch.randint(1, 11, (100, 200, 300), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 11, (100, 200, 300), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 100,
                 "M": 200,
                 "K": 300,
@@ -120,8 +123,8 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.randint(1, 3, (500, 500, 500), device="cuda", dtype=dtype)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.randint(1, 3, (500, 500, 500), device=self.device, dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,

--- a/challenges/medium/47_subarray_sum/challenge.py
+++ b/challenges/medium/47_subarray_sum/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Subarray Sum", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Subarray Sum"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int, S: int, E: int):
         # Validate input types and shapes
@@ -32,8 +33,8 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.tensor([1, 2, 1, 3, 4], device="cuda", dtype=dtype)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.tensor([1, 2, 1, 3, 4], device=self.device, dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,
@@ -49,8 +50,8 @@ class Challenge(ChallengeBase):
         # basic_example
         tests.append(
             {
-                "input": torch.tensor([1, 2, 3, 4], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([1, 2, 3, 4], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 4,
                 "S": 0,
                 "E": 3,
@@ -60,8 +61,8 @@ class Challenge(ChallengeBase):
         # all_same_value
         tests.append(
             {
-                "input": torch.tensor([2] * 16, device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([2] * 16, device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 16,
                 "S": 0,
                 "E": 15,
@@ -71,8 +72,8 @@ class Challenge(ChallengeBase):
         # increasing_sequence
         tests.append(
             {
-                "input": torch.randint(1, 5, (32,), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 5, (32,), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 32,
                 "S": 0,
                 "E": 31,
@@ -82,8 +83,8 @@ class Challenge(ChallengeBase):
         # medium_size
         tests.append(
             {
-                "input": torch.randint(1, 10, (1000,), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 10, (1000,), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1000,
                 "S": 0,
                 "E": 500,
@@ -93,8 +94,8 @@ class Challenge(ChallengeBase):
         # large_size
         tests.append(
             {
-                "input": torch.randint(1, 11, (100000,), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 11, (100000,), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 100000,
                 "S": 123,
                 "E": 98765,
@@ -105,8 +106,8 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.randint(1, 11, (100000000,), device="cuda", dtype=dtype)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.randint(1, 11, (100000000,), device=self.device, dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,

--- a/challenges/medium/48_2d_subarray_sum/challenge.py
+++ b/challenges/medium/48_2d_subarray_sum/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="2D Subarray Sum", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "2D Subarray Sum"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -45,8 +46,8 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.tensor([[1, 2, 3], [4, 5, 1]], device="cuda", dtype=dtype)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.tensor([[1, 2, 3], [4, 5, 1]], device=self.device, dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,
@@ -65,8 +66,8 @@ class Challenge(ChallengeBase):
         # basic_example
         tests.append(
             {
-                "input": torch.tensor([[5, 10], [5, 2]], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([[5, 10], [5, 2]], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 2,
                 "M": 2,
                 "S_ROW": 0,
@@ -79,8 +80,8 @@ class Challenge(ChallengeBase):
         # all_same_value
         tests.append(
             {
-                "input": torch.tensor([[2] * 16] * 3, device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([[2] * 16] * 3, device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 3,
                 "M": 16,
                 "S_ROW": 0,
@@ -93,8 +94,8 @@ class Challenge(ChallengeBase):
         # increasing_sequence
         tests.append(
             {
-                "input": torch.randint(1, 11, (50, 50), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 11, (50, 50), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 50,
                 "M": 50,
                 "S_ROW": 0,
@@ -107,8 +108,8 @@ class Challenge(ChallengeBase):
         # medium_size
         tests.append(
             {
-                "input": torch.randint(1, 11, (100, 100), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 11, (100, 100), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 100,
                 "M": 100,
                 "S_ROW": 0,
@@ -121,8 +122,8 @@ class Challenge(ChallengeBase):
         # large_size
         tests.append(
             {
-                "input": torch.randint(1, 11, (1000, 1000), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 11, (1000, 1000), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1000,
                 "M": 1000,
                 "S_ROW": 10,
@@ -136,8 +137,8 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.randint(1, 11, (10000, 10000), device="cuda", dtype=dtype)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.randint(1, 11, (10000, 10000), device=self.device, dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,

--- a/challenges/medium/49_3d_subarray_sum/challenge.py
+++ b/challenges/medium/49_3d_subarray_sum/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="3D Subarray Sum", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "3D Subarray Sum"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -52,9 +53,9 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.int32
         input = torch.tensor(
-            [[[1, 2, 3], [4, 5, 1]], [[1, 1, 1], [2, 2, 2]]], device="cuda", dtype=dtype
+            [[[1, 2, 3], [4, 5, 1]], [[1, 1, 1], [2, 2, 2]]], device=self.device, dtype=dtype
         )
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,
@@ -76,8 +77,8 @@ class Challenge(ChallengeBase):
         # basic_example
         tests.append(
             {
-                "input": torch.tensor([[[5, 10], [5, 2], [2, 2]]], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([[[5, 10], [5, 2], [2, 2]]], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1,
                 "M": 3,
                 "K": 2,
@@ -93,8 +94,8 @@ class Challenge(ChallengeBase):
         # all_same_value
         tests.append(
             {
-                "input": torch.tensor([[[2] * 16] * 20] * 30, device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([[[2] * 16] * 20] * 30, device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 30,
                 "M": 20,
                 "K": 16,
@@ -110,8 +111,8 @@ class Challenge(ChallengeBase):
         # increasing_sequence
         tests.append(
             {
-                "input": torch.randint(1, 11, (50, 50, 50), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 11, (50, 50, 50), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 50,
                 "M": 50,
                 "K": 50,
@@ -127,8 +128,8 @@ class Challenge(ChallengeBase):
         # medium_size
         tests.append(
             {
-                "input": torch.randint(1, 11, (77, 87, 57), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 11, (77, 87, 57), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 77,
                 "M": 87,
                 "K": 57,
@@ -144,8 +145,8 @@ class Challenge(ChallengeBase):
         # large_size
         tests.append(
             {
-                "input": torch.randint(1, 11, (100, 100, 100), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(1, 11, (100, 100, 100), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 100,
                 "M": 100,
                 "K": 100,
@@ -162,8 +163,8 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.randint(1, 11, (500, 500, 500), device="cuda", dtype=dtype)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.randint(1, 11, (500, 500, 500), device=self.device, dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,

--- a/challenges/medium/4_reduction/challenge.py
+++ b/challenges/medium/4_reduction/challenge.py
@@ -6,8 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(name="Reduction", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free")
+    name = "Reduction"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int):
         assert input.shape == (N,)
@@ -25,8 +28,10 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        input = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], device="cuda", dtype=dtype)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.tensor(
+            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], device=self.device, dtype=dtype
+        )
+        output = torch.empty(1, device=self.device, dtype=dtype)
         N = 8
         return {"input": input, "output": output, "N": N}
 
@@ -37,65 +42,69 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "input": torch.tensor(
-                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], device="cuda", dtype=dtype
+                    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], device=self.device, dtype=dtype
                 ),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 8,
             }
         )
         # negative_numbers
         tests.append(
             {
-                "input": torch.tensor([-2.5, 1.5, -1.0, 2.0], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([-2.5, 1.5, -1.0, 2.0], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
         # single_element
         tests.append(
             {
-                "input": torch.tensor([42.0], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([42.0], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1,
             }
         )
         # all_zeros
         tests.append(
             {
-                "input": torch.zeros(1024, device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.zeros(1024, device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1024,
             }
         )
         # all_ones
         tests.append(
             {
-                "input": torch.ones(1024, device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.ones(1024, device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1024,
             }
         )
         # non_power_of_two
         tests.append(
             {
-                "input": torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 5,
             }
         )
         # large_random
         tests.append(
             {
-                "input": torch.empty(10000, device="cuda", dtype=dtype).uniform_(-1000.0, 1000.0),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.empty(10000, device=self.device, dtype=dtype).uniform_(
+                    -1000.0, 1000.0
+                ),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 10000,
             }
         )
         # large_random_2
         tests.append(
             {
-                "input": torch.empty(15000000, device="cuda", dtype=dtype).uniform_(0.0, 1000.0),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.empty(15000000, device=self.device, dtype=dtype).uniform_(
+                    0.0, 1000.0
+                ),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 15000000,
             }
         )
@@ -104,6 +113,6 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 4_194_304
-        input = torch.empty(N, device="cuda", dtype=dtype).uniform_(0.0, 1000.0)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.empty(N, device=self.device, dtype=dtype).uniform_(0.0, 1000.0)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {"input": input, "output": output, "N": N}

--- a/challenges/medium/50_rms_normalization/challenge.py
+++ b/challenges/medium/50_rms_normalization/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="RMS Normalization", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "RMS Normalization"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -46,10 +47,10 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 4
-        input = torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype)
+        input = torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype)
         gamma = 1.0
         beta = 0.0
-        output = torch.empty(N, device="cuda", dtype=dtype)
+        output = torch.empty(N, device=self.device, dtype=dtype)
         eps = 1e-5
         return {
             "input": input,
@@ -68,10 +69,10 @@ class Challenge(ChallengeBase):
         N = 3
         tests.append(
             {
-                "input": torch.tensor([1.0, 2.0, 3.0], device="cuda", dtype=dtype),
+                "input": torch.tensor([1.0, 2.0, 3.0], device=self.device, dtype=dtype),
                 "gamma": 1.0,
                 "beta": 0.0,
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
                 "eps": 1e-5,
             }
@@ -81,10 +82,10 @@ class Challenge(ChallengeBase):
         N = 1
         tests.append(
             {
-                "input": torch.tensor([5.0], device="cuda", dtype=dtype),
+                "input": torch.tensor([5.0], device=self.device, dtype=dtype),
                 "gamma": 2.0,
                 "beta": -1.0,
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
                 "eps": 1e-5,
             }
@@ -94,10 +95,10 @@ class Challenge(ChallengeBase):
         N = 4
         tests.append(
             {
-                "input": torch.zeros(N, device="cuda", dtype=dtype),
+                "input": torch.zeros(N, device=self.device, dtype=dtype),
                 "gamma": 1.0,
                 "beta": 0.0,
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
                 "eps": 1e-5,
             }
@@ -107,10 +108,12 @@ class Challenge(ChallengeBase):
         N = 5
         tests.append(
             {
-                "input": torch.tensor([-1.0, -2.0, -3.0, -4.0, -5.0], device="cuda", dtype=dtype),
+                "input": torch.tensor(
+                    [-1.0, -2.0, -3.0, -4.0, -5.0], device=self.device, dtype=dtype
+                ),
                 "gamma": 1.0,
                 "beta": 0.0,
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
                 "eps": 1e-5,
             }
@@ -120,10 +123,10 @@ class Challenge(ChallengeBase):
         N = 3
         tests.append(
             {
-                "input": torch.tensor([0.0, 1.0, 2.0], device="cuda", dtype=dtype),
+                "input": torch.tensor([0.0, 1.0, 2.0], device=self.device, dtype=dtype),
                 "gamma": 0.5,
                 "beta": -1.0,
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
                 "eps": 1e-5,
             }
@@ -133,10 +136,10 @@ class Challenge(ChallengeBase):
         N = 8
         tests.append(
             {
-                "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
+                "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
                 "gamma": 1.5,
                 "beta": 0.0,
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
                 "eps": 1e-5,
             }
@@ -146,10 +149,10 @@ class Challenge(ChallengeBase):
         N = 2000
         tests.append(
             {
-                "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-100.0, 100.0),
+                "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-100.0, 100.0),
                 "gamma": 1.3,
                 "beta": 0.0,
-                "output": torch.empty(N, device="cuda", dtype=dtype),
+                "output": torch.empty(N, device=self.device, dtype=dtype),
                 "N": N,
                 "eps": 1e-5,
             }
@@ -161,10 +164,10 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         N = 100000
         return {
-            "input": torch.empty(N, device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
+            "input": torch.empty(N, device=self.device, dtype=dtype).uniform_(-10.0, 10.0),
             "gamma": 1.5,
             "beta": 0.0,
-            "output": torch.empty(N, device="cuda", dtype=dtype),
+            "output": torch.empty(N, device=self.device, dtype=dtype),
             "N": N,
             "eps": 1e-5,
         }

--- a/challenges/medium/51_max_subarray_sum/challenge.py
+++ b/challenges/medium/51_max_subarray_sum/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Max Subarray Sum", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Max Subarray Sum"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int, window_size: int):
         # Validate input types and shapes
@@ -49,8 +50,8 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.tensor([1, 2, 4, 2, 3], device="cuda", dtype=dtype)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.tensor([1, 2, 4, 2, 3], device=self.device, dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,
@@ -65,8 +66,8 @@ class Challenge(ChallengeBase):
         # basic_example
         tests.append(
             {
-                "input": torch.tensor([-1, -4, -2, 1], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([-1, -4, -2, 1], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 4,
                 "window_size": 3,
             }
@@ -75,8 +76,8 @@ class Challenge(ChallengeBase):
         # all_same_value
         tests.append(
             {
-                "input": torch.tensor([2] * 16, device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([2] * 16, device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 16,
                 "window_size": 15,
             }
@@ -85,8 +86,8 @@ class Challenge(ChallengeBase):
         # all_minus_value
         tests.append(
             {
-                "input": torch.tensor([-10] * 1000, device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([-10] * 1000, device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1000,
                 "window_size": 500,
             }
@@ -95,8 +96,8 @@ class Challenge(ChallengeBase):
         # increasing_sequence
         tests.append(
             {
-                "input": torch.randint(-10, 11, (123,), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(-10, 11, (123,), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 123,
                 "window_size": 7,
             }
@@ -105,8 +106,8 @@ class Challenge(ChallengeBase):
         # medium_size
         tests.append(
             {
-                "input": torch.randint(-10, 11, (1000,), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(-10, 11, (1000,), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1000,
                 "window_size": 476,
             }
@@ -115,8 +116,8 @@ class Challenge(ChallengeBase):
         # large_size
         tests.append(
             {
-                "input": torch.randint(-10, 11, (10000,), device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.randint(-10, 11, (10000,), device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 10000,
                 "window_size": 7011,
             }
@@ -126,8 +127,8 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.int32
-        input = torch.randint(-10, 11, (50000,), device="cuda", dtype=dtype)
-        output = torch.empty(1, device="cuda", dtype=dtype)
+        input = torch.randint(-10, 11, (50000,), device=self.device, dtype=dtype)
+        output = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,

--- a/challenges/medium/55_attn_w_linear_bias/challenge.py
+++ b/challenges/medium/55_attn_w_linear_bias/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Attention with Linear Biases",
-            atol=1e-04,
-            rtol=1e-04,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Attention with Linear Biases"
+    atol = 0.0001
+    rtol = 0.0001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -57,18 +54,20 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        Q = torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype)
+        Q = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
+        )
         K = torch.tensor(
             [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
         V = torch.tensor(
             [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        output = torch.empty(2, 4, device="cuda", dtype=dtype)
+        output = torch.empty(2, 4, device=self.device, dtype=dtype)
         return {"Q": Q, "K": K, "V": V, "output": output, "M": 2, "N": 3, "d": 4, "alpha": 0.5}
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
@@ -78,10 +77,10 @@ class Challenge(ChallengeBase):
         # basic_example 1
         tests.append(
             {
-                "Q": torch.tensor([[1.0, 2.0]], device="cuda", dtype=dtype),
-                "K": torch.tensor([[1.0, 0.0], [0.0, 1.0]], device="cuda", dtype=dtype),
-                "V": torch.tensor([[3.0, 4.0], [5.0, 6.0]], device="cuda", dtype=dtype),
-                "output": torch.empty(1, 2, device="cuda", dtype=dtype),
+                "Q": torch.tensor([[1.0, 2.0]], device=self.device, dtype=dtype),
+                "K": torch.tensor([[1.0, 0.0], [0.0, 1.0]], device=self.device, dtype=dtype),
+                "V": torch.tensor([[3.0, 4.0], [5.0, 6.0]], device=self.device, dtype=dtype),
+                "output": torch.empty(1, 2, device=self.device, dtype=dtype),
                 "M": 1,
                 "N": 2,
                 "d": 2,
@@ -93,19 +92,19 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "Q": torch.tensor(
-                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype
+                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
                 ),
                 "K": torch.tensor(
                     [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "V": torch.tensor(
                     [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "output": torch.empty(2, 4, device="cuda", dtype=dtype),
+                "output": torch.empty(2, 4, device=self.device, dtype=dtype),
                 "M": 2,
                 "N": 3,
                 "d": 4,
@@ -116,10 +115,10 @@ class Challenge(ChallengeBase):
         # zero_matrices
         tests.append(
             {
-                "Q": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "K": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "V": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "output": torch.empty(3, 5, device="cuda", dtype=dtype),
+                "Q": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "K": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "V": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "output": torch.empty(3, 5, device=self.device, dtype=dtype),
                 "M": 3,
                 "N": 3,
                 "d": 5,
@@ -132,20 +131,20 @@ class Challenge(ChallengeBase):
             {
                 "Q": torch.tensor(
                     [[-1.0, 2.0, -3.0], [4.0, -5.0, 6.0], [-7.0, 8.0, -9.0], [10.0, -11.0, 12.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "K": torch.tensor(
                     [[2.0, -1.0, 3.0], [-4.0, 5.0, -6.0], [7.0, -8.0, 9.0], [-10.0, 11.0, -12.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "V": torch.tensor(
                     [[1.0, 0.5, -0.5], [-1.0, 2.0, 3.0], [4.0, -2.0, 1.0], [0.0, 1.0, -1.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "output": torch.empty(4, 3, device="cuda", dtype=dtype),
+                "output": torch.empty(4, 3, device=self.device, dtype=dtype),
                 "M": 4,
                 "N": 4,
                 "d": 3,
@@ -156,10 +155,10 @@ class Challenge(ChallengeBase):
         # large_matrices
         tests.append(
             {
-                "Q": torch.empty((64, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "K": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "V": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "output": torch.empty(64, 32, device="cuda", dtype=dtype),
+                "Q": torch.empty((64, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "K": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "V": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "output": torch.empty(64, 32, device=self.device, dtype=dtype),
                 "M": 64,
                 "N": 128,
                 "d": 32,
@@ -170,10 +169,10 @@ class Challenge(ChallengeBase):
         # different alpha
         tests.append(
             {
-                "Q": torch.empty((64, 32), device="cuda", dtype=dtype).uniform_(-1, 1),
-                "K": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-1, 1),
-                "V": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-1, 1),
-                "output": torch.empty(64, 32, device="cuda", dtype=dtype),
+                "Q": torch.empty((64, 32), device=self.device, dtype=dtype).uniform_(-1, 1),
+                "K": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-1, 1),
+                "V": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-1, 1),
+                "output": torch.empty(64, 32, device=self.device, dtype=dtype),
                 "M": 64,
                 "N": 128,
                 "d": 32,
@@ -186,8 +185,8 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         M, N, d = 2048, 2048, 1024
-        Q = torch.empty((M, d), device="cuda", dtype=dtype).uniform_(-0.1, 0.1)
-        K = torch.empty((N, d), device="cuda", dtype=dtype).uniform_(-0.1, 0.1)
-        V = torch.empty((N, d), device="cuda", dtype=dtype).uniform_(-0.1, 0.1)
-        output = torch.empty(M, d, device="cuda", dtype=dtype)
+        Q = torch.empty((M, d), device=self.device, dtype=dtype).uniform_(-0.1, 0.1)
+        K = torch.empty((N, d), device=self.device, dtype=dtype).uniform_(-0.1, 0.1)
+        V = torch.empty((N, d), device=self.device, dtype=dtype).uniform_(-0.1, 0.1)
+        output = torch.empty(M, d, device=self.device, dtype=dtype)
         return {"Q": Q, "K": K, "V": V, "output": output, "M": M, "N": N, "d": d, "alpha": 0.5}

--- a/challenges/medium/57_fp16_batched_matmul/challenge.py
+++ b/challenges/medium/57_fp16_batched_matmul/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="FP16 Batched Matrix Multiplication",
-            atol=5e-2,
-            rtol=5e-2,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "FP16 Batched Matrix Multiplication"
+    atol = 0.05
+    rtol = 0.05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self, A: torch.Tensor, B: torch.Tensor, C: torch.Tensor, BATCH: int, M: int, N: int, K: int
@@ -43,20 +40,20 @@ class Challenge(ChallengeBase):
         BATCH, M, K, N = 2, 2, 3, 2
         A = torch.tensor(
             [[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
         B = torch.tensor(
             [[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], [[6.0, 5.0], [4.0, 3.0], [2.0, 1.0]]],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        C = torch.empty(BATCH, M, N, device="cuda", dtype=dtype)
+        C = torch.empty(BATCH, M, N, device=self.device, dtype=dtype)
         return {"A": A, "B": B, "C": C, "BATCH": BATCH, "M": M, "N": N, "K": K}
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
         dtype = torch.float16
-        device = "cuda"
+        device = self.device
         tests = []
 
         # 1. basic_example
@@ -112,7 +109,7 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float16
         BATCH, M, N, K = 32, 256, 256, 256
-        A = torch.empty(BATCH, M, K, device="cuda", dtype=dtype).uniform_(-5.0, 5.0)
-        B = torch.empty(BATCH, K, N, device="cuda", dtype=dtype).uniform_(-5.0, 5.0)
-        C = torch.empty(BATCH, M, N, device="cuda", dtype=dtype)
+        A = torch.empty(BATCH, M, K, device=self.device, dtype=dtype).uniform_(-5.0, 5.0)
+        B = torch.empty(BATCH, K, N, device=self.device, dtype=dtype).uniform_(-5.0, 5.0)
+        C = torch.empty(BATCH, M, N, device=self.device, dtype=dtype)
         return {"A": A, "B": B, "C": C, "BATCH": BATCH, "M": M, "N": N, "K": K}

--- a/challenges/medium/58_fp16_dot_product/challenge.py
+++ b/challenges/medium/58_fp16_dot_product/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="FP16 Dot Product", atol=5e-2, rtol=5e-2, num_gpus=1, access_tier="free"
-        )
+    name = "FP16 Dot Product"
+    atol = 0.05
+    rtol = 0.05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, A: torch.Tensor, B: torch.Tensor, result: torch.Tensor, N: int):
         assert A.shape == (N,)
@@ -31,9 +32,9 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float16
-        A = torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype)
-        B = torch.tensor([5.0, 6.0, 7.0, 8.0], device="cuda", dtype=dtype)
-        result = torch.empty(1, device="cuda", dtype=dtype)
+        A = torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype)
+        B = torch.tensor([5.0, 6.0, 7.0, 8.0], device=self.device, dtype=dtype)
+        result = torch.empty(1, device=self.device, dtype=dtype)
         return {
             "A": A,
             "B": B,
@@ -47,63 +48,63 @@ class Challenge(ChallengeBase):
         # basic_small
         tests.append(
             {
-                "A": torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([5.0, 6.0, 7.0, 8.0], device="cuda", dtype=dtype),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.tensor([1.0, 2.0, 3.0, 4.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([5.0, 6.0, 7.0, 8.0], device=self.device, dtype=dtype),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
         # all_zeros
         tests.append(
             {
-                "A": torch.tensor([0.0] * 16, device="cuda", dtype=dtype),
-                "B": torch.tensor([0.0] * 16, device="cuda", dtype=dtype),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.tensor([0.0] * 16, device=self.device, dtype=dtype),
+                "B": torch.tensor([0.0] * 16, device=self.device, dtype=dtype),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 16,
             }
         )
         # negative_numbers
         tests.append(
             {
-                "A": torch.tensor([-1.0, -2.0, -3.0, -4.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([-5.0, -6.0, -7.0, -8.0], device="cuda", dtype=dtype),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.tensor([-1.0, -2.0, -3.0, -4.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([-5.0, -6.0, -7.0, -8.0], device=self.device, dtype=dtype),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
         # mixed_positive_negative
         tests.append(
             {
-                "A": torch.tensor([1.0, -2.0, 3.0, -4.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([-1.0, 2.0, -3.0, 4.0], device="cuda", dtype=dtype),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.tensor([1.0, -2.0, 3.0, -4.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([-1.0, 2.0, -3.0, 4.0], device=self.device, dtype=dtype),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
         # orthogonal_vectors
         tests.append(
             {
-                "A": torch.tensor([1.0, 0.0, 0.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([0.0, 1.0, 0.0], device="cuda", dtype=dtype),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.tensor([1.0, 0.0, 0.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([0.0, 1.0, 0.0], device=self.device, dtype=dtype),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 3,
             }
         )
         # medium_sized_vector
         tests.append(
             {
-                "A": torch.empty(1000, device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "B": torch.empty(1000, device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.empty(1000, device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "B": torch.empty(1000, device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1000,
             }
         )
         # large_vector
         tests.append(
             {
-                "A": torch.empty(10000, device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "B": torch.empty(10000, device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "result": torch.empty(1, device="cuda", dtype=dtype),
+                "A": torch.empty(10000, device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "B": torch.empty(10000, device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "result": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 10000,
             }
         )
@@ -112,9 +113,9 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float16
         N = 100000000
-        A = torch.empty(N, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        B = torch.empty(N, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        result = torch.zeros(1, device="cuda", dtype=dtype)
+        A = torch.empty(N, device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        B = torch.empty(N, device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        result = torch.zeros(1, device=self.device, dtype=dtype)
         return {
             "A": A,
             "B": B,

--- a/challenges/medium/5_softmax/challenge.py
+++ b/challenges/medium/5_softmax/challenge.py
@@ -6,8 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(name="Softmax", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free")
+    name = "Softmax"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, input: torch.Tensor, output: torch.Tensor, N: int):
         assert input.shape == output.shape == (N,)
@@ -27,8 +30,8 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        input = torch.tensor([1.0, 2.0, 3.0], device="cuda", dtype=dtype)
-        output = torch.empty(3, device="cuda", dtype=dtype)
+        input = torch.tensor([1.0, 2.0, 3.0], device=self.device, dtype=dtype)
+        output = torch.empty(3, device=self.device, dtype=dtype)
         N = 3
         return {"input": input, "output": output, "N": N}
 
@@ -38,80 +41,80 @@ class Challenge(ChallengeBase):
         # basic_small
         tests.append(
             {
-                "input": torch.tensor([1.0, 2.0, 3.0], device="cuda", dtype=dtype),
-                "output": torch.empty(3, device="cuda", dtype=dtype),
+                "input": torch.tensor([1.0, 2.0, 3.0], device=self.device, dtype=dtype),
+                "output": torch.empty(3, device=self.device, dtype=dtype),
                 "N": 3,
             }
         )
         # all_zeros
         tests.append(
             {
-                "input": torch.tensor([0.0, 0.0, 0.0, 0.0], device="cuda", dtype=dtype),
-                "output": torch.empty(4, device="cuda", dtype=dtype),
+                "input": torch.tensor([0.0, 0.0, 0.0, 0.0], device=self.device, dtype=dtype),
+                "output": torch.empty(4, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
         # negative_numbers
         tests.append(
             {
-                "input": torch.tensor([-1.0, -2.0, -3.0], device="cuda", dtype=dtype),
-                "output": torch.empty(3, device="cuda", dtype=dtype),
+                "input": torch.tensor([-1.0, -2.0, -3.0], device=self.device, dtype=dtype),
+                "output": torch.empty(3, device=self.device, dtype=dtype),
                 "N": 3,
             }
         )
         # mixed_positive_negative
         tests.append(
             {
-                "input": torch.tensor([1.0, -2.0, 3.0, -4.0], device="cuda", dtype=dtype),
-                "output": torch.empty(4, device="cuda", dtype=dtype),
+                "input": torch.tensor([1.0, -2.0, 3.0, -4.0], device=self.device, dtype=dtype),
+                "output": torch.empty(4, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
         # very_small_numbers
         tests.append(
             {
-                "input": torch.tensor([1e-6, 1e-7, 1e-8, 1e-9], device="cuda", dtype=dtype),
-                "output": torch.empty(4, device="cuda", dtype=dtype),
+                "input": torch.tensor([1e-6, 1e-7, 1e-8, 1e-9], device=self.device, dtype=dtype),
+                "output": torch.empty(4, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
         # large_numbers
         tests.append(
             {
-                "input": torch.tensor([10.0, 15.0, 20.0], device="cuda", dtype=dtype),
-                "output": torch.empty(3, device="cuda", dtype=dtype),
+                "input": torch.tensor([10.0, 15.0, 20.0], device=self.device, dtype=dtype),
+                "output": torch.empty(3, device=self.device, dtype=dtype),
                 "N": 3,
             }
         )
         # single_element
         tests.append(
             {
-                "input": torch.tensor([5.0], device="cuda", dtype=dtype),
-                "output": torch.empty(1, device="cuda", dtype=dtype),
+                "input": torch.tensor([5.0], device=self.device, dtype=dtype),
+                "output": torch.empty(1, device=self.device, dtype=dtype),
                 "N": 1,
             }
         )
         # all_same_values
         tests.append(
             {
-                "input": torch.tensor([2.5] * 10, device="cuda", dtype=dtype),
-                "output": torch.empty(10, device="cuda", dtype=dtype),
+                "input": torch.tensor([2.5] * 10, device=self.device, dtype=dtype),
+                "output": torch.empty(10, device=self.device, dtype=dtype),
                 "N": 10,
             }
         )
         # large_array
         tests.append(
             {
-                "input": torch.empty(2048, device="cuda", dtype=dtype).uniform_(0.0, 10.0),
-                "output": torch.empty(2048, device="cuda", dtype=dtype),
+                "input": torch.empty(2048, device=self.device, dtype=dtype).uniform_(0.0, 10.0),
+                "output": torch.empty(2048, device=self.device, dtype=dtype),
                 "N": 2048,
             }
         )
         # large_max_small_values
         tests.append(
             {
-                "input": torch.tensor([1000.0, 1.0, 2.0, 3.0], device="cuda", dtype=dtype),
-                "output": torch.empty(4, device="cuda", dtype=dtype),
+                "input": torch.tensor([1000.0, 1.0, 2.0, 3.0], device=self.device, dtype=dtype),
+                "output": torch.empty(4, device=self.device, dtype=dtype),
                 "N": 4,
             }
         )
@@ -120,6 +123,6 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 500000
-        input = torch.empty(N, device="cuda", dtype=dtype).uniform_(-10.0, 10.0)
-        output = torch.empty(N, device="cuda", dtype=dtype)
+        input = torch.empty(N, device=self.device, dtype=dtype).uniform_(-10.0, 10.0)
+        output = torch.empty(N, device=self.device, dtype=dtype)
         return {"input": input, "output": output, "N": N}

--- a/challenges/medium/60_top_p_sampling/challenge.py
+++ b/challenges/medium/60_top_p_sampling/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Top-p Sampling", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Top-p Sampling"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -58,10 +59,10 @@ class Challenge(ChallengeBase):
         }
 
     def generate_example_test(self) -> Dict[str, Any]:
-        logits = torch.tensor([1.0, 2.0, 3.0, 0.5], device="cuda", dtype=torch.float32)
-        p = torch.tensor([0.9], device="cuda", dtype=torch.float32)
-        seed = torch.tensor([42], device="cuda", dtype=torch.int32)
-        sampled_token = torch.zeros(1, device="cuda", dtype=torch.int32)
+        logits = torch.tensor([1.0, 2.0, 3.0, 0.5], device=self.device, dtype=torch.float32)
+        p = torch.tensor([0.9], device=self.device, dtype=torch.float32)
+        seed = torch.tensor([42], device=self.device, dtype=torch.int32)
+        sampled_token = torch.zeros(1, device=self.device, dtype=torch.int32)
 
         return {
             "logits": logits,
@@ -74,10 +75,10 @@ class Challenge(ChallengeBase):
     def generate_functional_test(self) -> List[Dict[str, Any]]:
         tests = []
 
-        logits = torch.tensor([1.0, 2.0, 3.0], device="cuda", dtype=torch.float32)
-        p = torch.tensor([0.95], device="cuda", dtype=torch.float32)
-        seed = torch.tensor([123], device="cuda", dtype=torch.int32)
-        sampled_token = torch.zeros(1, device="cuda", dtype=torch.int32)
+        logits = torch.tensor([1.0, 2.0, 3.0], device=self.device, dtype=torch.float32)
+        p = torch.tensor([0.95], device=self.device, dtype=torch.float32)
+        seed = torch.tensor([123], device=self.device, dtype=torch.int32)
+        sampled_token = torch.zeros(1, device=self.device, dtype=torch.int32)
         tests.append(
             {
                 "logits": logits,
@@ -88,10 +89,10 @@ class Challenge(ChallengeBase):
             }
         )
 
-        logits = torch.randn(10, device="cuda", dtype=torch.float32)
-        p = torch.tensor([0.9], device="cuda", dtype=torch.float32)
-        seed = torch.tensor([456], device="cuda", dtype=torch.int32)
-        sampled_token = torch.zeros(1, device="cuda", dtype=torch.int32)
+        logits = torch.randn(10, device=self.device, dtype=torch.float32)
+        p = torch.tensor([0.9], device=self.device, dtype=torch.float32)
+        seed = torch.tensor([456], device=self.device, dtype=torch.int32)
+        sampled_token = torch.zeros(1, device=self.device, dtype=torch.int32)
         tests.append(
             {
                 "logits": logits,
@@ -102,10 +103,10 @@ class Challenge(ChallengeBase):
             }
         )
 
-        logits = torch.randn(100, device="cuda", dtype=torch.float32) * 5.0
-        p = torch.tensor([0.85], device="cuda", dtype=torch.float32)
-        seed = torch.tensor([789], device="cuda", dtype=torch.int32)
-        sampled_token = torch.zeros(1, device="cuda", dtype=torch.int32)
+        logits = torch.randn(100, device=self.device, dtype=torch.float32) * 5.0
+        p = torch.tensor([0.85], device=self.device, dtype=torch.float32)
+        seed = torch.tensor([789], device=self.device, dtype=torch.int32)
+        sampled_token = torch.zeros(1, device=self.device, dtype=torch.int32)
         tests.append(
             {
                 "logits": logits,
@@ -116,11 +117,11 @@ class Challenge(ChallengeBase):
             }
         )
 
-        logits = torch.zeros(50, device="cuda", dtype=torch.float32)
+        logits = torch.zeros(50, device=self.device, dtype=torch.float32)
         logits[0] = 10.0
-        p = torch.tensor([0.5], device="cuda", dtype=torch.float32)
-        seed = torch.tensor([111], device="cuda", dtype=torch.int32)
-        sampled_token = torch.zeros(1, device="cuda", dtype=torch.int32)
+        p = torch.tensor([0.5], device=self.device, dtype=torch.float32)
+        seed = torch.tensor([111], device=self.device, dtype=torch.int32)
+        sampled_token = torch.zeros(1, device=self.device, dtype=torch.int32)
         tests.append(
             {
                 "logits": logits,
@@ -131,10 +132,10 @@ class Challenge(ChallengeBase):
             }
         )
 
-        logits = torch.randn(500, device="cuda", dtype=torch.float32) * 3.0
-        p = torch.tensor([0.92], device="cuda", dtype=torch.float32)
-        seed = torch.tensor([222], device="cuda", dtype=torch.int32)
-        sampled_token = torch.zeros(1, device="cuda", dtype=torch.int32)
+        logits = torch.randn(500, device=self.device, dtype=torch.float32) * 3.0
+        p = torch.tensor([0.92], device=self.device, dtype=torch.float32)
+        seed = torch.tensor([222], device=self.device, dtype=torch.int32)
+        sampled_token = torch.zeros(1, device=self.device, dtype=torch.int32)
         tests.append(
             {
                 "logits": logits,
@@ -145,10 +146,10 @@ class Challenge(ChallengeBase):
             }
         )
 
-        logits = torch.linspace(-5, 5, 200, device="cuda", dtype=torch.float32)
-        p = torch.tensor([0.8], device="cuda", dtype=torch.float32)
-        seed = torch.tensor([333], device="cuda", dtype=torch.int32)
-        sampled_token = torch.zeros(1, device="cuda", dtype=torch.int32)
+        logits = torch.linspace(-5, 5, 200, device=self.device, dtype=torch.float32)
+        p = torch.tensor([0.8], device=self.device, dtype=torch.float32)
+        seed = torch.tensor([333], device=self.device, dtype=torch.int32)
+        sampled_token = torch.zeros(1, device=self.device, dtype=torch.int32)
         tests.append(
             {
                 "logits": logits,
@@ -159,10 +160,10 @@ class Challenge(ChallengeBase):
             }
         )
 
-        logits = torch.randn(1000, device="cuda", dtype=torch.float32) * 2.0
-        p = torch.tensor([0.95], device="cuda", dtype=torch.float32)
-        seed = torch.tensor([444], device="cuda", dtype=torch.int32)
-        sampled_token = torch.zeros(1, device="cuda", dtype=torch.int32)
+        logits = torch.randn(1000, device=self.device, dtype=torch.float32) * 2.0
+        p = torch.tensor([0.95], device=self.device, dtype=torch.float32)
+        seed = torch.tensor([444], device=self.device, dtype=torch.int32)
+        sampled_token = torch.zeros(1, device=self.device, dtype=torch.int32)
         tests.append(
             {
                 "logits": logits,
@@ -173,10 +174,10 @@ class Challenge(ChallengeBase):
             }
         )
 
-        logits = torch.randn(5000, device="cuda", dtype=torch.float32)
-        p = torch.tensor([0.9], device="cuda", dtype=torch.float32)
-        seed = torch.tensor([555], device="cuda", dtype=torch.int32)
-        sampled_token = torch.zeros(1, device="cuda", dtype=torch.int32)
+        logits = torch.randn(5000, device=self.device, dtype=torch.float32)
+        p = torch.tensor([0.9], device=self.device, dtype=torch.float32)
+        seed = torch.tensor([555], device=self.device, dtype=torch.int32)
+        sampled_token = torch.zeros(1, device=self.device, dtype=torch.int32)
         tests.append(
             {
                 "logits": logits,
@@ -191,10 +192,10 @@ class Challenge(ChallengeBase):
 
     def generate_performance_test(self) -> Dict[str, Any]:
         vocab_size = 50000
-        logits = torch.randn(vocab_size, device="cuda", dtype=torch.float32) * 3.0
-        p = torch.tensor([0.9], device="cuda", dtype=torch.float32)
-        seed = torch.tensor([999], device="cuda", dtype=torch.int32)
-        sampled_token = torch.zeros(1, device="cuda", dtype=torch.int32)
+        logits = torch.randn(vocab_size, device=self.device, dtype=torch.float32) * 3.0
+        p = torch.tensor([0.9], device=self.device, dtype=torch.float32)
+        seed = torch.tensor([999], device=self.device, dtype=torch.int32)
+        sampled_token = torch.zeros(1, device=self.device, dtype=torch.int32)
 
         return {
             "logits": logits,

--- a/challenges/medium/61_rope_embedding/challenge.py
+++ b/challenges/medium/61_rope_embedding/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Rotary Positional Embedding",
-            atol=1e-4,
-            rtol=1e-4,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Rotary Positional Embedding"
+    atol = 0.0001
+    rtol = 0.0001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -57,10 +54,10 @@ class Challenge(ChallengeBase):
         D = 64
         dtype = torch.float32
 
-        Q = torch.randn(M, D, device="cuda", dtype=dtype)
-        Cos = torch.randn(M, D, device="cuda", dtype=dtype)
-        Sin = torch.randn(M, D, device="cuda", dtype=dtype)
-        Output = torch.zeros(M, D, device="cuda", dtype=dtype)
+        Q = torch.randn(M, D, device=self.device, dtype=dtype)
+        Cos = torch.randn(M, D, device=self.device, dtype=dtype)
+        Sin = torch.randn(M, D, device=self.device, dtype=dtype)
+        Output = torch.zeros(M, D, device=self.device, dtype=dtype)
 
         return {
             "Q": Q,
@@ -80,10 +77,10 @@ class Challenge(ChallengeBase):
         D = 4
         tests.append(
             {
-                "Q": torch.randn(M, D, device="cuda", dtype=dtype),
-                "cos": torch.randn(M, D, device="cuda", dtype=dtype),
-                "sin": torch.randn(M, D, device="cuda", dtype=dtype),
-                "output": torch.zeros(M, D, device="cuda", dtype=dtype),
+                "Q": torch.randn(M, D, device=self.device, dtype=dtype),
+                "cos": torch.randn(M, D, device=self.device, dtype=dtype),
+                "sin": torch.randn(M, D, device=self.device, dtype=dtype),
+                "output": torch.zeros(M, D, device=self.device, dtype=dtype),
                 "M": M,
                 "D": D,
             }
@@ -94,10 +91,10 @@ class Challenge(ChallengeBase):
         D = 64
         tests.append(
             {
-                "Q": torch.randn(M, D, device="cuda", dtype=dtype),
-                "cos": torch.randn(M, D, device="cuda", dtype=dtype),
-                "sin": torch.randn(M, D, device="cuda", dtype=dtype),
-                "output": torch.zeros(M, D, device="cuda", dtype=dtype),
+                "Q": torch.randn(M, D, device=self.device, dtype=dtype),
+                "cos": torch.randn(M, D, device=self.device, dtype=dtype),
+                "sin": torch.randn(M, D, device=self.device, dtype=dtype),
+                "output": torch.zeros(M, D, device=self.device, dtype=dtype),
                 "M": M,
                 "D": D,
             }
@@ -106,10 +103,10 @@ class Challenge(ChallengeBase):
         # zero_matrices: outputs should remain zero when inputs are zero
         tests.append(
             {
-                "Q": torch.zeros((3, 6), device="cuda", dtype=dtype),
-                "cos": torch.zeros((3, 6), device="cuda", dtype=dtype),
-                "sin": torch.zeros((3, 6), device="cuda", dtype=dtype),
-                "output": torch.zeros(3, 6, device="cuda", dtype=dtype),
+                "Q": torch.zeros((3, 6), device=self.device, dtype=dtype),
+                "cos": torch.zeros((3, 6), device=self.device, dtype=dtype),
+                "sin": torch.zeros((3, 6), device=self.device, dtype=dtype),
+                "output": torch.zeros(3, 6, device=self.device, dtype=dtype),
                 "M": 3,
                 "D": 6,
             }
@@ -118,10 +115,10 @@ class Challenge(ChallengeBase):
         # minimal_dims: smallest even D that still allows rotation
         tests.append(
             {
-                "Q": torch.randn((1, 2), device="cuda", dtype=dtype),
-                "cos": torch.randn((1, 2), device="cuda", dtype=dtype),
-                "sin": torch.randn((1, 2), device="cuda", dtype=dtype),
-                "output": torch.zeros(1, 2, device="cuda", dtype=dtype),
+                "Q": torch.randn((1, 2), device=self.device, dtype=dtype),
+                "cos": torch.randn((1, 2), device=self.device, dtype=dtype),
+                "sin": torch.randn((1, 2), device=self.device, dtype=dtype),
+                "output": torch.zeros(1, 2, device=self.device, dtype=dtype),
                 "M": 1,
                 "D": 2,
             }
@@ -132,20 +129,20 @@ class Challenge(ChallengeBase):
             {
                 "Q": torch.tensor(
                     [[-1.0, 2.0, -3.0, 4.0], [5.0, -6.0, 7.0, -8.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "cos": torch.tensor(
                     [[0.5, 0.5, 0.5, 0.5], [0.1, 0.2, 0.3, 0.4]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "sin": torch.tensor(
                     [[0.5, -0.5, 0.5, -0.5], [0.4, -0.3, 0.2, -0.1]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "output": torch.zeros(2, 4, device="cuda", dtype=dtype),
+                "output": torch.zeros(2, 4, device=self.device, dtype=dtype),
                 "M": 2,
                 "D": 4,
             }
@@ -154,10 +151,10 @@ class Challenge(ChallengeBase):
         # large_matrices: random uniform values for stress testing
         tests.append(
             {
-                "Q": torch.empty((256, 128), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "cos": torch.empty((256, 128), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "sin": torch.empty((256, 128), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "output": torch.zeros(256, 128, device="cuda", dtype=dtype),
+                "Q": torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "cos": torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "sin": torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "output": torch.zeros(256, 128, device=self.device, dtype=dtype),
                 "M": 256,
                 "D": 128,
             }
@@ -170,10 +167,10 @@ class Challenge(ChallengeBase):
         D = 128
         dtype = torch.float32
         return {
-            "Q": torch.randn(M, D, device="cuda", dtype=dtype),
-            "cos": torch.randn(M, D, device="cuda", dtype=dtype),
-            "sin": torch.randn(M, D, device="cuda", dtype=dtype),
-            "output": torch.zeros(M, D, device="cuda", dtype=dtype),
+            "Q": torch.randn(M, D, device=self.device, dtype=dtype),
+            "cos": torch.randn(M, D, device=self.device, dtype=dtype),
+            "sin": torch.randn(M, D, device=self.device, dtype=dtype),
+            "output": torch.zeros(M, D, device=self.device, dtype=dtype),
             "M": M,
             "D": D,
         }

--- a/challenges/medium/64_weight_dequantization/challenge.py
+++ b/challenges/medium/64_weight_dequantization/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Weight Dequantization", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "Weight Dequantization"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self, X: torch.Tensor, S: torch.Tensor, Y: torch.Tensor, M: int, N: int, TILE_SIZE: int
@@ -41,11 +42,11 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         M, N = 256, 256
         TILE_SIZE = 128
-        X = torch.randn(M, N, device="cuda", dtype=torch.float32)
+        X = torch.randn(M, N, device=self.device, dtype=torch.float32)
         # S shape
         s_rows = (M + TILE_SIZE - 1) // TILE_SIZE
         s_cols = (N + TILE_SIZE - 1) // TILE_SIZE
-        S = torch.randn(s_rows, s_cols, device="cuda", dtype=torch.float32)
+        S = torch.randn(s_rows, s_cols, device=self.device, dtype=torch.float32)
         Y = torch.empty_like(X)
 
         return {
@@ -85,9 +86,9 @@ class Challenge(ChallengeBase):
             s_cols = (N + TILE_SIZE - 1) // TILE_SIZE
             tests.append(
                 {
-                    "X": torch.randn(M, N, device="cuda", dtype=torch.float32),
-                    "S": torch.randn(s_rows, s_cols, device="cuda", dtype=torch.float32),
-                    "Y": torch.zeros(M, N, device="cuda", dtype=torch.float32),
+                    "X": torch.randn(M, N, device=self.device, dtype=torch.float32),
+                    "S": torch.randn(s_rows, s_cols, device=self.device, dtype=torch.float32),
+                    "Y": torch.zeros(M, N, device=self.device, dtype=torch.float32),
                     "M": M,
                     "N": N,
                     "TILE_SIZE": TILE_SIZE,
@@ -100,9 +101,9 @@ class Challenge(ChallengeBase):
         s_cols = (N + TILE_SIZE - 1) // TILE_SIZE
         tests.append(
             {
-                "X": torch.zeros(M, N, device="cuda", dtype=torch.float32),
-                "S": torch.randn(s_rows, s_cols, device="cuda", dtype=torch.float32),
-                "Y": torch.zeros(M, N, device="cuda", dtype=torch.float32),
+                "X": torch.zeros(M, N, device=self.device, dtype=torch.float32),
+                "S": torch.randn(s_rows, s_cols, device=self.device, dtype=torch.float32),
+                "Y": torch.zeros(M, N, device=self.device, dtype=torch.float32),
                 "M": M,
                 "N": N,
                 "TILE_SIZE": TILE_SIZE,
@@ -115,9 +116,9 @@ class Challenge(ChallengeBase):
         s_cols = (N + TILE_SIZE - 1) // TILE_SIZE
         tests.append(
             {
-                "X": torch.randn(M, N, device="cuda", dtype=torch.float32).sub_(0.5),
-                "S": torch.randn(s_rows, s_cols, device="cuda", dtype=torch.float32).sub_(0.5),
-                "Y": torch.zeros(M, N, device="cuda", dtype=torch.float32),
+                "X": torch.randn(M, N, device=self.device, dtype=torch.float32).sub_(0.5),
+                "S": torch.randn(s_rows, s_cols, device=self.device, dtype=torch.float32).sub_(0.5),
+                "Y": torch.zeros(M, N, device=self.device, dtype=torch.float32),
                 "M": M,
                 "N": N,
                 "TILE_SIZE": TILE_SIZE,
@@ -129,10 +130,10 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         M, N = 8192, 8192
         TILE_SIZE = 128
-        X = torch.randn(M, N, device="cuda", dtype=torch.float32)
+        X = torch.randn(M, N, device=self.device, dtype=torch.float32)
         s_rows = (M + TILE_SIZE - 1) // TILE_SIZE
         s_cols = (N + TILE_SIZE - 1) // TILE_SIZE
-        S = torch.randn(s_rows, s_cols, device="cuda", dtype=torch.float32)
+        S = torch.randn(s_rows, s_cols, device=self.device, dtype=torch.float32)
         Y = torch.empty_like(X)
 
         return {

--- a/challenges/medium/67_moe_topk_gating/challenge.py
+++ b/challenges/medium/67_moe_topk_gating/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="MoE Top-K Gating", atol=1e-05, rtol=1e-05, num_gpus=1, access_tier="free"
-        )
+    name = "MoE Top-K Gating"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -29,7 +30,6 @@ class Challenge(ChallengeBase):
         assert logits.shape == (M, E)
         assert topk_weights.shape == (M, k)
         assert topk_indices.shape == (M, k)
-        assert logits.is_cuda and topk_weights.is_cuda and topk_indices.is_cuda
         assert topk_indices.dtype == torch.int32
 
         # 1. TopK Selection
@@ -62,10 +62,10 @@ class Challenge(ChallengeBase):
 
         # Example from problem description
         logits_data = torch.tensor(
-            [[1.0, 2.0, 3.0, 4.0], [4.0, 3.0, 2.0, 1.0]], device="cuda", dtype=dtype_float
+            [[1.0, 2.0, 3.0, 4.0], [4.0, 3.0, 2.0, 1.0]], device=self.device, dtype=dtype_float
         )
-        topk_weights_data = torch.zeros((M, k), device="cuda", dtype=dtype_float)
-        topk_indices_data = torch.zeros((M, k), device="cuda", dtype=dtype_int)
+        topk_weights_data = torch.zeros((M, k), device=self.device, dtype=dtype_float)
+        topk_indices_data = torch.zeros((M, k), device=self.device, dtype=dtype_int)
 
         return {
             "logits": logits_data,
@@ -85,10 +85,12 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "logits": torch.tensor(
-                    [[1.0, 2.0, 3.0, 4.0], [4.0, 3.0, 2.0, 1.0]], device="cuda", dtype=dtype_float
+                    [[1.0, 2.0, 3.0, 4.0], [4.0, 3.0, 2.0, 1.0]],
+                    device=self.device,
+                    dtype=dtype_float,
                 ),
-                "topk_weights": torch.zeros((2, 2), device="cuda", dtype=dtype_float),
-                "topk_indices": torch.zeros((2, 2), device="cuda", dtype=dtype_int),
+                "topk_weights": torch.zeros((2, 2), device=self.device, dtype=dtype_float),
+                "topk_indices": torch.zeros((2, 2), device=self.device, dtype=dtype_int),
                 "M": 2,
                 "E": 4,
                 "k": 2,
@@ -100,11 +102,11 @@ class Challenge(ChallengeBase):
             {
                 "logits": torch.tensor(
                     [[5.0, 1.0, 3.0], [2.0, 8.0, 4.0], [6.0, 2.0, 9.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype_float,
                 ),
-                "topk_weights": torch.zeros((3, 1), device="cuda", dtype=dtype_float),
-                "topk_indices": torch.zeros((3, 1), device="cuda", dtype=dtype_int),
+                "topk_weights": torch.zeros((3, 1), device=self.device, dtype=dtype_float),
+                "topk_indices": torch.zeros((3, 1), device=self.device, dtype=dtype_int),
                 "M": 3,
                 "E": 3,
                 "k": 1,
@@ -115,10 +117,10 @@ class Challenge(ChallengeBase):
         test_cases.append(
             {
                 "logits": torch.tensor(
-                    [[1.0, 2.0, 3.0], [3.0, 1.0, 2.0]], device="cuda", dtype=dtype_float
+                    [[1.0, 2.0, 3.0], [3.0, 1.0, 2.0]], device=self.device, dtype=dtype_float
                 ),
-                "topk_weights": torch.zeros((2, 3), device="cuda", dtype=dtype_float),
-                "topk_indices": torch.zeros((2, 3), device="cuda", dtype=dtype_int),
+                "topk_weights": torch.zeros((2, 3), device=self.device, dtype=dtype_float),
+                "topk_indices": torch.zeros((2, 3), device=self.device, dtype=dtype_int),
                 "M": 2,
                 "E": 3,
                 "k": 3,
@@ -129,9 +131,9 @@ class Challenge(ChallengeBase):
         torch.manual_seed(42)
         test_cases.append(
             {
-                "logits": torch.randn((4, 8), device="cuda", dtype=dtype_float),
-                "topk_weights": torch.zeros((4, 2), device="cuda", dtype=dtype_float),
-                "topk_indices": torch.zeros((4, 2), device="cuda", dtype=dtype_int),
+                "logits": torch.randn((4, 8), device=self.device, dtype=dtype_float),
+                "topk_weights": torch.zeros((4, 2), device=self.device, dtype=dtype_float),
+                "topk_indices": torch.zeros((4, 2), device=self.device, dtype=dtype_int),
                 "M": 4,
                 "E": 8,
                 "k": 2,
@@ -142,9 +144,9 @@ class Challenge(ChallengeBase):
         torch.manual_seed(123)
         test_cases.append(
             {
-                "logits": torch.randn((8, 64), device="cuda", dtype=dtype_float),
-                "topk_weights": torch.zeros((8, 2), device="cuda", dtype=dtype_float),
-                "topk_indices": torch.zeros((8, 2), device="cuda", dtype=dtype_int),
+                "logits": torch.randn((8, 64), device=self.device, dtype=dtype_float),
+                "topk_weights": torch.zeros((8, 2), device=self.device, dtype=dtype_float),
+                "topk_indices": torch.zeros((8, 2), device=self.device, dtype=dtype_int),
                 "M": 8,
                 "E": 64,
                 "k": 2,
@@ -156,11 +158,11 @@ class Challenge(ChallengeBase):
             {
                 "logits": torch.tensor(
                     [[-1.0, -2.0, -3.0, -4.0], [-4.0, -1.0, -2.0, -3.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype_float,
                 ),
-                "topk_weights": torch.zeros((2, 2), device="cuda", dtype=dtype_float),
-                "topk_indices": torch.zeros((2, 2), device="cuda", dtype=dtype_int),
+                "topk_weights": torch.zeros((2, 2), device=self.device, dtype=dtype_float),
+                "topk_indices": torch.zeros((2, 2), device=self.device, dtype=dtype_int),
                 "M": 2,
                 "E": 4,
                 "k": 2,
@@ -171,9 +173,9 @@ class Challenge(ChallengeBase):
         torch.manual_seed(456)
         test_cases.append(
             {
-                "logits": torch.randn((100, 16), device="cuda", dtype=dtype_float),
-                "topk_weights": torch.zeros((100, 4), device="cuda", dtype=dtype_float),
-                "topk_indices": torch.zeros((100, 4), device="cuda", dtype=dtype_int),
+                "logits": torch.randn((100, 16), device=self.device, dtype=dtype_float),
+                "topk_weights": torch.zeros((100, 4), device=self.device, dtype=dtype_float),
+                "topk_indices": torch.zeros((100, 4), device=self.device, dtype=dtype_int),
                 "M": 100,
                 "E": 16,
                 "k": 4,
@@ -191,9 +193,9 @@ class Challenge(ChallengeBase):
 
         torch.manual_seed(789)
         return {
-            "logits": torch.randn((M, E), device="cuda", dtype=dtype_float),
-            "topk_weights": torch.zeros((M, k), device="cuda", dtype=dtype_float),
-            "topk_indices": torch.zeros((M, k), device="cuda", dtype=dtype_int),
+            "logits": torch.randn((M, E), device=self.device, dtype=dtype_float),
+            "topk_weights": torch.zeros((M, k), device=self.device, dtype=dtype_float),
+            "topk_indices": torch.zeros((M, k), device=self.device, dtype=dtype_int),
             "M": M,
             "E": E,
             "k": k,

--- a/challenges/medium/69_jacobi_stencil_2d/challenge.py
+++ b/challenges/medium/69_jacobi_stencil_2d/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="2D Jacobi Stencil",
-            atol=1e-05,
-            rtol=1e-05,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "2D Jacobi Stencil"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -25,7 +22,6 @@ class Challenge(ChallengeBase):
         assert input.shape == (rows, cols)
         assert output.shape == (rows, cols)
         assert input.dtype == torch.float32
-        assert input.device.type == "cuda"
 
         # Copy boundary cells unchanged
         output.copy_(input)
@@ -56,10 +52,10 @@ class Challenge(ChallengeBase):
                 [9.0, 10.0, 11.0, 12.0],
                 [13.0, 14.0, 15.0, 16.0],
             ],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        output = torch.empty((4, 4), device="cuda", dtype=dtype)
+        output = torch.empty((4, 4), device=self.device, dtype=dtype)
         return {
             "input": input,
             "output": output,
@@ -76,10 +72,10 @@ class Challenge(ChallengeBase):
             {
                 "input": torch.tensor(
                     [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "output": torch.empty((3, 3), device="cuda", dtype=dtype),
+                "output": torch.empty((3, 3), device=self.device, dtype=dtype),
                 "rows": 3,
                 "cols": 3,
             }
@@ -88,8 +84,8 @@ class Challenge(ChallengeBase):
         # minimal_1x1 (all boundary, no interior cells)
         tests.append(
             {
-                "input": torch.tensor([[42.0]], device="cuda", dtype=dtype),
-                "output": torch.empty((1, 1), device="cuda", dtype=dtype),
+                "input": torch.tensor([[42.0]], device=self.device, dtype=dtype),
+                "output": torch.empty((1, 1), device=self.device, dtype=dtype),
                 "rows": 1,
                 "cols": 1,
             }
@@ -98,8 +94,8 @@ class Challenge(ChallengeBase):
         # single_row (all boundary)
         tests.append(
             {
-                "input": torch.tensor([[1.0, 2.0, 3.0, 4.0]], device="cuda", dtype=dtype),
-                "output": torch.empty((1, 4), device="cuda", dtype=dtype),
+                "input": torch.tensor([[1.0, 2.0, 3.0, 4.0]], device=self.device, dtype=dtype),
+                "output": torch.empty((1, 4), device=self.device, dtype=dtype),
                 "rows": 1,
                 "cols": 4,
             }
@@ -108,8 +104,10 @@ class Challenge(ChallengeBase):
         # single_col (all boundary)
         tests.append(
             {
-                "input": torch.tensor([[1.0], [2.0], [3.0], [4.0]], device="cuda", dtype=dtype),
-                "output": torch.empty((4, 1), device="cuda", dtype=dtype),
+                "input": torch.tensor(
+                    [[1.0], [2.0], [3.0], [4.0]], device=self.device, dtype=dtype
+                ),
+                "output": torch.empty((4, 1), device=self.device, dtype=dtype),
                 "rows": 4,
                 "cols": 1,
             }
@@ -118,8 +116,8 @@ class Challenge(ChallengeBase):
         # all_zeros (interior should stay zero)
         tests.append(
             {
-                "input": torch.zeros((16, 16), device="cuda", dtype=dtype),
-                "output": torch.empty((16, 16), device="cuda", dtype=dtype),
+                "input": torch.zeros((16, 16), device=self.device, dtype=dtype),
+                "output": torch.empty((16, 16), device=self.device, dtype=dtype),
                 "rows": 16,
                 "cols": 16,
             }
@@ -128,8 +126,8 @@ class Challenge(ChallengeBase):
         # uniform_constant (interior stays the same when all values equal)
         tests.append(
             {
-                "input": torch.full((32, 32), 3.14, device="cuda", dtype=dtype),
-                "output": torch.empty((32, 32), device="cuda", dtype=dtype),
+                "input": torch.full((32, 32), 3.14, device=self.device, dtype=dtype),
+                "output": torch.empty((32, 32), device=self.device, dtype=dtype),
                 "rows": 32,
                 "cols": 32,
             }
@@ -138,8 +136,8 @@ class Challenge(ChallengeBase):
         # power_of_2_square_64
         tests.append(
             {
-                "input": torch.empty((64, 64), device="cuda", dtype=dtype).uniform_(-5.0, 5.0),
-                "output": torch.empty((64, 64), device="cuda", dtype=dtype),
+                "input": torch.empty((64, 64), device=self.device, dtype=dtype).uniform_(-5.0, 5.0),
+                "output": torch.empty((64, 64), device=self.device, dtype=dtype),
                 "rows": 64,
                 "cols": 64,
             }
@@ -148,8 +146,10 @@ class Challenge(ChallengeBase):
         # power_of_2_square_128
         tests.append(
             {
-                "input": torch.empty((128, 128), device="cuda", dtype=dtype).uniform_(-10.0, 10.0),
-                "output": torch.empty((128, 128), device="cuda", dtype=dtype),
+                "input": torch.empty((128, 128), device=self.device, dtype=dtype).uniform_(
+                    -10.0, 10.0
+                ),
+                "output": torch.empty((128, 128), device=self.device, dtype=dtype),
                 "rows": 128,
                 "cols": 128,
             }
@@ -158,8 +158,8 @@ class Challenge(ChallengeBase):
         # non_power_of_2_30x30
         tests.append(
             {
-                "input": torch.empty((30, 30), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "output": torch.empty((30, 30), device="cuda", dtype=dtype),
+                "input": torch.empty((30, 30), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "output": torch.empty((30, 30), device=self.device, dtype=dtype),
                 "rows": 30,
                 "cols": 30,
             }
@@ -168,8 +168,10 @@ class Challenge(ChallengeBase):
         # non_power_of_2_100x100
         tests.append(
             {
-                "input": torch.empty((100, 100), device="cuda", dtype=dtype).uniform_(-3.0, 3.0),
-                "output": torch.empty((100, 100), device="cuda", dtype=dtype),
+                "input": torch.empty((100, 100), device=self.device, dtype=dtype).uniform_(
+                    -3.0, 3.0
+                ),
+                "output": torch.empty((100, 100), device=self.device, dtype=dtype),
                 "rows": 100,
                 "cols": 100,
             }
@@ -178,8 +180,10 @@ class Challenge(ChallengeBase):
         # non_square_255x33
         tests.append(
             {
-                "input": torch.empty((255, 33), device="cuda", dtype=dtype).uniform_(-2.0, 2.0),
-                "output": torch.empty((255, 33), device="cuda", dtype=dtype),
+                "input": torch.empty((255, 33), device=self.device, dtype=dtype).uniform_(
+                    -2.0, 2.0
+                ),
+                "output": torch.empty((255, 33), device=self.device, dtype=dtype),
                 "rows": 255,
                 "cols": 33,
             }
@@ -188,8 +192,10 @@ class Challenge(ChallengeBase):
         # negative_values_non_square_17x97
         tests.append(
             {
-                "input": torch.empty((17, 97), device="cuda", dtype=dtype).uniform_(-100.0, 0.0),
-                "output": torch.empty((17, 97), device="cuda", dtype=dtype),
+                "input": torch.empty((17, 97), device=self.device, dtype=dtype).uniform_(
+                    -100.0, 0.0
+                ),
+                "output": torch.empty((17, 97), device=self.device, dtype=dtype),
                 "rows": 17,
                 "cols": 97,
             }
@@ -198,8 +204,10 @@ class Challenge(ChallengeBase):
         # realistic_medium_512x256
         tests.append(
             {
-                "input": torch.empty((512, 256), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "output": torch.empty((512, 256), device="cuda", dtype=dtype),
+                "input": torch.empty((512, 256), device=self.device, dtype=dtype).uniform_(
+                    -1.0, 1.0
+                ),
+                "output": torch.empty((512, 256), device=self.device, dtype=dtype),
                 "rows": 512,
                 "cols": 256,
             }
@@ -208,8 +216,10 @@ class Challenge(ChallengeBase):
         # realistic_large_1024x1024
         tests.append(
             {
-                "input": torch.empty((1024, 1024), device="cuda", dtype=dtype).uniform_(-5.0, 5.0),
-                "output": torch.empty((1024, 1024), device="cuda", dtype=dtype),
+                "input": torch.empty((1024, 1024), device=self.device, dtype=dtype).uniform_(
+                    -5.0, 5.0
+                ),
+                "output": torch.empty((1024, 1024), device=self.device, dtype=dtype),
                 "rows": 1024,
                 "cols": 1024,
             }
@@ -222,8 +232,8 @@ class Challenge(ChallengeBase):
         rows = 8192
         cols = 8192
         return {
-            "input": torch.empty((rows, cols), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-            "output": torch.empty((rows, cols), device="cuda", dtype=dtype),
+            "input": torch.empty((rows, cols), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+            "output": torch.empty((rows, cols), device=self.device, dtype=dtype),
             "rows": rows,
             "cols": cols,
         }

--- a/challenges/medium/6_softmax_attention/challenge.py
+++ b/challenges/medium/6_softmax_attention/challenge.py
@@ -6,10 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Softmax Attention", atol=1e-04, rtol=1e-04, num_gpus=1, access_tier="free"
-        )
+    name = "Softmax Attention"
+    atol = 0.0001
+    rtol = 0.0001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -39,18 +40,20 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        Q = torch.tensor([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype)
+        Q = torch.tensor(
+            [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
+        )
         K = torch.tensor(
             [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
         V = torch.tensor(
             [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        output = torch.empty(2, 4, device="cuda", dtype=dtype)
+        output = torch.empty(2, 4, device=self.device, dtype=dtype)
         return {"Q": Q, "K": K, "V": V, "output": output, "M": 2, "N": 3, "d": 4}
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
@@ -61,19 +64,19 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "Q": torch.tensor(
-                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device="cuda", dtype=dtype
+                    [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], device=self.device, dtype=dtype
                 ),
                 "K": torch.tensor(
                     [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "V": torch.tensor(
                     [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "output": torch.empty(2, 4, device="cuda", dtype=dtype),
+                "output": torch.empty(2, 4, device=self.device, dtype=dtype),
                 "M": 2,
                 "N": 3,
                 "d": 4,
@@ -83,10 +86,10 @@ class Challenge(ChallengeBase):
         # zero_matrices
         tests.append(
             {
-                "Q": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "K": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "V": torch.zeros((3, 5), device="cuda", dtype=dtype),
-                "output": torch.empty(3, 5, device="cuda", dtype=dtype),
+                "Q": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "K": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "V": torch.zeros((3, 5), device=self.device, dtype=dtype),
+                "output": torch.empty(3, 5, device=self.device, dtype=dtype),
                 "M": 3,
                 "N": 3,
                 "d": 5,
@@ -98,20 +101,20 @@ class Challenge(ChallengeBase):
             {
                 "Q": torch.tensor(
                     [[-1.0, 2.0, -3.0], [4.0, -5.0, 6.0], [-7.0, 8.0, -9.0], [10.0, -11.0, 12.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "K": torch.tensor(
                     [[2.0, -1.0, 3.0], [-4.0, 5.0, -6.0], [7.0, -8.0, 9.0], [-10.0, 11.0, -12.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
                 "V": torch.tensor(
                     [[1.0, 0.5, -0.5], [-1.0, 2.0, 3.0], [4.0, -2.0, 1.0], [0.0, 1.0, -1.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "output": torch.empty(4, 3, device="cuda", dtype=dtype),
+                "output": torch.empty(4, 3, device=self.device, dtype=dtype),
                 "M": 4,
                 "N": 4,
                 "d": 3,
@@ -121,10 +124,10 @@ class Challenge(ChallengeBase):
         # large_matrices
         tests.append(
             {
-                "Q": torch.empty((64, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "K": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "V": torch.empty((128, 32), device="cuda", dtype=dtype).uniform_(-0.1, 0.1),
-                "output": torch.empty(64, 32, device="cuda", dtype=dtype),
+                "Q": torch.empty((64, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "K": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "V": torch.empty((128, 32), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
+                "output": torch.empty(64, 32, device=self.device, dtype=dtype),
                 "M": 64,
                 "N": 128,
                 "d": 32,
@@ -136,8 +139,8 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         M, N, d = 512, 256, 128
-        Q = torch.empty((512, 128), device="cuda", dtype=dtype).uniform_(-0.1, 0.1)
-        K = torch.empty((256, 128), device="cuda", dtype=dtype).uniform_(-0.1, 0.1)
-        V = torch.empty((256, 128), device="cuda", dtype=dtype).uniform_(-0.1, 0.1)
-        output = torch.empty(M, d, device="cuda", dtype=dtype)
+        Q = torch.empty((512, 128), device=self.device, dtype=dtype).uniform_(-0.1, 0.1)
+        K = torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-0.1, 0.1)
+        V = torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-0.1, 0.1)
+        output = torch.empty(M, d, device=self.device, dtype=dtype)
         return {"Q": Q, "K": K, "V": V, "output": output, "M": M, "N": N, "d": d}

--- a/challenges/medium/70_segmented_prefix_sum/challenge.py
+++ b/challenges/medium/70_segmented_prefix_sum/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Segmented Exclusive Prefix Sum",
-            atol=1e-03,
-            rtol=1e-03,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Segmented Exclusive Prefix Sum"
+    atol = 0.001
+    rtol = 0.001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -27,10 +24,9 @@ class Challenge(ChallengeBase):
         assert output.shape == (N,)
         assert values.dtype == torch.float32
         assert flags.dtype == torch.int32
-        assert values.device.type == "cuda"
 
         # Global exclusive prefix sum (use float64 for accuracy in reference).
-        excl = torch.empty(N, dtype=torch.float64, device="cuda")
+        excl = torch.empty(N, dtype=torch.float64, device=self.device)
         excl[0] = 0.0
         if N > 1:
             excl[1:] = torch.cumsum(values[:-1].double(), dim=0)
@@ -60,9 +56,9 @@ class Challenge(ChallengeBase):
         dtype_i = torch.int32
         # Three segments: [1,2,3], [4,5], [6]
         # exclusive prefix sums: [0,1,3], [0,4], [0]
-        values = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], device="cuda", dtype=dtype_f)
-        flags = torch.tensor([1, 0, 0, 1, 0, 1], device="cuda", dtype=dtype_i)
-        output = torch.empty(6, device="cuda", dtype=dtype_f)
+        values = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], device=self.device, dtype=dtype_f)
+        flags = torch.tensor([1, 0, 0, 1, 0, 1], device=self.device, dtype=dtype_i)
+        output = torch.empty(6, device=self.device, dtype=dtype_f)
         return {
             "values": values,
             "flags": flags,
@@ -82,9 +78,9 @@ class Challenge(ChallengeBase):
             for s in segs:
                 flags[s] = 1
             return {
-                "values": torch.tensor(vals, device="cuda", dtype=dtype_f),
-                "flags": flags.cuda(),
-                "output": torch.empty(N, device="cuda", dtype=dtype_f),
+                "values": torch.tensor(vals, device=self.device, dtype=dtype_f),
+                "flags": flags.to(self.device),
+                "output": torch.empty(N, device=self.device, dtype=dtype_f),
                 "N": N,
             }
 
@@ -99,9 +95,9 @@ class Challenge(ChallengeBase):
                 flags[i] = 1
                 i += max(1, int(torch.randint(1, 2 * avg_seg_len + 1, (1,)).item()))
             return {
-                "values": vals.cuda(),
-                "flags": flags.cuda(),
-                "output": torch.empty(N, device="cuda", dtype=dtype_f),
+                "values": vals.to(self.device),
+                "flags": flags.to(self.device),
+                "output": torch.empty(N, device=self.device, dtype=dtype_f),
                 "N": N,
             }
 
@@ -164,8 +160,8 @@ class Challenge(ChallengeBase):
         seg_starts = torch.arange(256, N, 256, dtype=torch.long)
         flags[seg_starts] = 1
         return {
-            "values": vals.cuda(),
-            "flags": flags.cuda(),
-            "output": torch.empty(N, device="cuda", dtype=dtype_f),
+            "values": vals.to(self.device),
+            "flags": flags.to(self.device),
+            "output": torch.empty(N, device=self.device, dtype=dtype_f),
             "N": N,
         }

--- a/challenges/medium/71_parallel_merge/challenge.py
+++ b/challenges/medium/71_parallel_merge/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Parallel Merge",
-            atol=0.0,
-            rtol=0.0,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Parallel Merge"
+    atol = 0.0
+    rtol = 0.0
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -29,7 +26,6 @@ class Challenge(ChallengeBase):
         assert A.dtype == torch.float32
         assert B.dtype == torch.float32
         assert C.dtype == torch.float32
-        assert A.device.type == "cuda"
 
         merged, _ = torch.sort(torch.cat([A, B]))
         C.copy_(merged)
@@ -45,17 +41,17 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        A = torch.tensor([1.0, 3.0, 5.0, 7.0], device="cuda", dtype=dtype)
-        B = torch.tensor([2.0, 4.0, 6.0, 8.0], device="cuda", dtype=dtype)
+        A = torch.tensor([1.0, 3.0, 5.0, 7.0], device=self.device, dtype=dtype)
+        B = torch.tensor([2.0, 4.0, 6.0, 8.0], device=self.device, dtype=dtype)
         M, N = 4, 4
-        C = torch.empty(M + N, device="cuda", dtype=dtype)
+        C = torch.empty(M + N, device=self.device, dtype=dtype)
         return {"A": A, "B": B, "C": C, "M": M, "N": N}
 
     def _make_test(self, M: int, N: int, lo: float = -10.0, hi: float = 10.0) -> Dict[str, Any]:
         dtype = torch.float32
-        A, _ = torch.sort(torch.empty(M, device="cuda", dtype=dtype).uniform_(lo, hi))
-        B, _ = torch.sort(torch.empty(N, device="cuda", dtype=dtype).uniform_(lo, hi))
-        C = torch.empty(M + N, device="cuda", dtype=dtype)
+        A, _ = torch.sort(torch.empty(M, device=self.device, dtype=dtype).uniform_(lo, hi))
+        B, _ = torch.sort(torch.empty(N, device=self.device, dtype=dtype).uniform_(lo, hi))
+        C = torch.empty(M + N, device=self.device, dtype=dtype)
         return {"A": A, "B": B, "C": C, "M": M, "N": N}
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
@@ -65,27 +61,27 @@ class Challenge(ChallengeBase):
         # Edge cases — tiny sizes
         tests.append(
             {
-                "A": torch.tensor([0.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([1.0], device="cuda", dtype=dtype),
-                "C": torch.empty(2, device="cuda", dtype=dtype),
+                "A": torch.tensor([0.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([1.0], device=self.device, dtype=dtype),
+                "C": torch.empty(2, device=self.device, dtype=dtype),
                 "M": 1,
                 "N": 1,
             }
         )
         tests.append(
             {
-                "A": torch.tensor([2.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([-1.0, 1.0, 3.0], device="cuda", dtype=dtype),
-                "C": torch.empty(4, device="cuda", dtype=dtype),
+                "A": torch.tensor([2.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([-1.0, 1.0, 3.0], device=self.device, dtype=dtype),
+                "C": torch.empty(4, device=self.device, dtype=dtype),
                 "M": 1,
                 "N": 3,
             }
         )
         tests.append(
             {
-                "A": torch.tensor([-1.0, 1.0, 3.0], device="cuda", dtype=dtype),
-                "B": torch.tensor([2.0], device="cuda", dtype=dtype),
-                "C": torch.empty(4, device="cuda", dtype=dtype),
+                "A": torch.tensor([-1.0, 1.0, 3.0], device=self.device, dtype=dtype),
+                "B": torch.tensor([2.0], device=self.device, dtype=dtype),
+                "C": torch.empty(4, device=self.device, dtype=dtype),
                 "M": 3,
                 "N": 1,
             }
@@ -93,9 +89,9 @@ class Challenge(ChallengeBase):
         # All zeros
         tests.append(
             {
-                "A": torch.zeros(2, device="cuda", dtype=dtype),
-                "B": torch.zeros(2, device="cuda", dtype=dtype),
-                "C": torch.empty(4, device="cuda", dtype=dtype),
+                "A": torch.zeros(2, device=self.device, dtype=dtype),
+                "B": torch.zeros(2, device=self.device, dtype=dtype),
+                "C": torch.empty(4, device=self.device, dtype=dtype),
                 "M": 2,
                 "N": 2,
             }
@@ -114,26 +110,30 @@ class Challenge(ChallengeBase):
         tests.append(self._make_test(255, 127))
 
         # A entirely less than B (no interleaving needed)
-        A_low, _ = torch.sort(torch.empty(256, device="cuda", dtype=dtype).uniform_(-20.0, -10.0))
-        B_high, _ = torch.sort(torch.empty(256, device="cuda", dtype=dtype).uniform_(10.0, 20.0))
+        A_low, _ = torch.sort(
+            torch.empty(256, device=self.device, dtype=dtype).uniform_(-20.0, -10.0)
+        )
+        B_high, _ = torch.sort(
+            torch.empty(256, device=self.device, dtype=dtype).uniform_(10.0, 20.0)
+        )
         tests.append(
             {
                 "A": A_low,
                 "B": B_high,
-                "C": torch.empty(512, device="cuda", dtype=dtype),
+                "C": torch.empty(512, device=self.device, dtype=dtype),
                 "M": 256,
                 "N": 256,
             }
         )
 
         # Many duplicate values
-        A_dup = torch.sort(torch.randint(0, 5, (128,), device="cuda").to(dtype=dtype)).values
-        B_dup = torch.sort(torch.randint(0, 5, (128,), device="cuda").to(dtype=dtype)).values
+        A_dup = torch.sort(torch.randint(0, 5, (128,), device=self.device).to(dtype=dtype)).values
+        B_dup = torch.sort(torch.randint(0, 5, (128,), device=self.device).to(dtype=dtype)).values
         tests.append(
             {
                 "A": A_dup,
                 "B": B_dup,
-                "C": torch.empty(256, device="cuda", dtype=dtype),
+                "C": torch.empty(256, device=self.device, dtype=dtype),
                 "M": 128,
                 "N": 128,
             }
@@ -148,7 +148,7 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         M = 25_000_000
         N = 25_000_000
-        A, _ = torch.sort(torch.empty(M, device="cuda", dtype=dtype).uniform_(-1.0, 1.0))
-        B, _ = torch.sort(torch.empty(N, device="cuda", dtype=dtype).uniform_(-1.0, 1.0))
-        C = torch.empty(M + N, device="cuda", dtype=dtype)
+        A, _ = torch.sort(torch.empty(M, device=self.device, dtype=dtype).uniform_(-1.0, 1.0))
+        B, _ = torch.sort(torch.empty(N, device=self.device, dtype=dtype).uniform_(-1.0, 1.0))
+        C = torch.empty(M + N, device=self.device, dtype=dtype)
         return {"A": A, "B": B, "C": C, "M": M, "N": N}

--- a/challenges/medium/72_stream_compaction/challenge.py
+++ b/challenges/medium/72_stream_compaction/challenge.py
@@ -6,21 +6,17 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Stream Compaction",
-            atol=0.0,
-            rtol=0.0,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Stream Compaction"
+    atol = 0.0
+    rtol = 0.0
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, A: torch.Tensor, N: int, out: torch.Tensor):
         assert A.shape == (N,), f"Expected A.shape=({N},), got {A.shape}"
         assert out.shape == (N,), f"Expected out.shape=({N},), got {out.shape}"
         assert A.dtype == torch.float32
         assert out.dtype == torch.float32
-        assert A.device.type == "cuda"
 
         mask = A > 0
         selected = A[mask]
@@ -36,15 +32,15 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        A = torch.tensor([1.0, -2.0, 3.0, 0.0, -1.0, 4.0], device="cuda", dtype=dtype)
+        A = torch.tensor([1.0, -2.0, 3.0, 0.0, -1.0, 4.0], device=self.device, dtype=dtype)
         N = 6
-        out = torch.zeros(N, device="cuda", dtype=dtype)
+        out = torch.zeros(N, device=self.device, dtype=dtype)
         return {"A": A, "N": N, "out": out}
 
     def _make_test(self, N: int, lo: float = -2.0, hi: float = 2.0) -> Dict[str, Any]:
         dtype = torch.float32
-        A = torch.empty(N, device="cuda", dtype=dtype).uniform_(lo, hi)
-        out = torch.zeros(N, device="cuda", dtype=dtype)
+        A = torch.empty(N, device=self.device, dtype=dtype).uniform_(lo, hi)
+        out = torch.zeros(N, device=self.device, dtype=dtype)
         return {"A": A, "N": N, "out": out}
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
@@ -55,36 +51,40 @@ class Challenge(ChallengeBase):
         # N=1, zero (not positive, nothing selected)
         tests.append(
             {
-                "A": torch.tensor([0.0], device="cuda", dtype=dtype),
+                "A": torch.tensor([0.0], device=self.device, dtype=dtype),
                 "N": 1,
-                "out": torch.zeros(1, device="cuda", dtype=dtype),
+                "out": torch.zeros(1, device=self.device, dtype=dtype),
             }
         )
         # N=1, positive (all selected)
         tests.append(
             {
-                "A": torch.tensor([5.0], device="cuda", dtype=dtype),
+                "A": torch.tensor([5.0], device=self.device, dtype=dtype),
                 "N": 1,
-                "out": torch.zeros(1, device="cuda", dtype=dtype),
+                "out": torch.zeros(1, device=self.device, dtype=dtype),
             }
         )
         # N=4, mixed with exact zeros and negatives
         tests.append(
             {
-                "A": torch.tensor([-1.0, 2.0, 0.0, 4.0], device="cuda", dtype=dtype),
+                "A": torch.tensor([-1.0, 2.0, 0.0, 4.0], device=self.device, dtype=dtype),
                 "N": 4,
-                "out": torch.zeros(4, device="cuda", dtype=dtype),
+                "out": torch.zeros(4, device=self.device, dtype=dtype),
             }
         )
 
         # Power-of-2 sizes
         # All positive — every element passes the predicate
-        A_all_pos = torch.rand(16, device="cuda", dtype=dtype) + 0.1
-        tests.append({"A": A_all_pos, "N": 16, "out": torch.zeros(16, device="cuda", dtype=dtype)})
+        A_all_pos = torch.rand(16, device=self.device, dtype=dtype) + 0.1
+        tests.append(
+            {"A": A_all_pos, "N": 16, "out": torch.zeros(16, device=self.device, dtype=dtype)}
+        )
 
         # All negative — no element passes the predicate
-        A_all_neg = -(torch.rand(32, device="cuda", dtype=dtype) + 0.1)
-        tests.append({"A": A_all_neg, "N": 32, "out": torch.zeros(32, device="cuda", dtype=dtype)})
+        A_all_neg = -(torch.rand(32, device=self.device, dtype=dtype) + 0.1)
+        tests.append(
+            {"A": A_all_neg, "N": 32, "out": torch.zeros(32, device=self.device, dtype=dtype)}
+        )
 
         # Mixed, wide range
         tests.append(self._make_test(256, lo=-5.0, hi=5.0))
@@ -102,6 +102,6 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         N = 50_000_000
-        A = torch.empty(N, device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        out = torch.zeros(N, device="cuda", dtype=dtype)
+        A = torch.empty(N, device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        out = torch.zeros(N, device=self.device, dtype=dtype)
         return {"A": A, "N": N, "out": out}

--- a/challenges/medium/75_sparse_matrix_dense_matrix_multiplication/challenge.py
+++ b/challenges/medium/75_sparse_matrix_dense_matrix_multiplication/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Sparse Matrix-Dense Matrix Multiplication",
-            atol=1e-03,
-            rtol=1e-03,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Sparse Matrix-Dense Matrix Multiplication"
+    atol = 0.001
+    rtol = 0.001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -46,9 +43,6 @@ class Challenge(ChallengeBase):
         ), f"C.shape {C.shape} does not match expected {(M, K)} or {(M * K,)}"
         assert A_matrix.dtype == torch.float32
         assert B_matrix.dtype == torch.float32
-        assert A_matrix.device.type == "cuda"
-        assert B_matrix.device.type == "cuda"
-        assert C.device.type == "cuda"
         result = torch.matmul(A_matrix, B_matrix)
         C.copy_(result.view(C.shape))
 
@@ -71,7 +65,7 @@ class Challenge(ChallengeBase):
                 [0.0, 3.0, 0.0, 0.0],
                 [0.0, 0.0, 4.0, 0.0],
             ],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
         B = torch.tensor(
@@ -81,10 +75,10 @@ class Challenge(ChallengeBase):
                 [5.0, 6.0],
                 [7.0, 8.0],
             ],
-            device="cuda",
+            device=self.device,
             dtype=dtype,
         )
-        C = torch.empty((3, 2), device="cuda", dtype=dtype)
+        C = torch.empty((3, 2), device=self.device, dtype=dtype)
         return {
             "A": A,
             "B": B,
@@ -102,9 +96,9 @@ class Challenge(ChallengeBase):
         # edge_1x1x1
         tests.append(
             {
-                "A": torch.tensor([[3.0]], device="cuda", dtype=dtype),
-                "B": torch.tensor([[2.0]], device="cuda", dtype=dtype),
-                "C": torch.empty((1, 1), device="cuda", dtype=dtype),
+                "A": torch.tensor([[3.0]], device=self.device, dtype=dtype),
+                "B": torch.tensor([[2.0]], device=self.device, dtype=dtype),
+                "C": torch.empty((1, 1), device=self.device, dtype=dtype),
                 "M": 1,
                 "N": 1,
                 "K": 1,
@@ -115,9 +109,9 @@ class Challenge(ChallengeBase):
         # edge_2x2_k1_spmv_like
         tests.append(
             {
-                "A": torch.tensor([[1.0, 0.0], [0.0, 2.0]], device="cuda", dtype=dtype),
-                "B": torch.tensor([[3.0], [4.0]], device="cuda", dtype=dtype),
-                "C": torch.empty((2, 1), device="cuda", dtype=dtype),
+                "A": torch.tensor([[1.0, 0.0], [0.0, 2.0]], device=self.device, dtype=dtype),
+                "B": torch.tensor([[3.0], [4.0]], device=self.device, dtype=dtype),
+                "C": torch.empty((2, 1), device=self.device, dtype=dtype),
                 "M": 2,
                 "N": 2,
                 "K": 1,
@@ -128,9 +122,11 @@ class Challenge(ChallengeBase):
         # edge_zero_matrix
         tests.append(
             {
-                "A": torch.zeros((3, 3), device="cuda", dtype=dtype),
-                "B": torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], device="cuda", dtype=dtype),
-                "C": torch.empty((3, 2), device="cuda", dtype=dtype),
+                "A": torch.zeros((3, 3), device=self.device, dtype=dtype),
+                "B": torch.tensor(
+                    [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], device=self.device, dtype=dtype
+                ),
+                "C": torch.empty((3, 2), device=self.device, dtype=dtype),
                 "M": 3,
                 "N": 3,
                 "K": 2,
@@ -141,13 +137,13 @@ class Challenge(ChallengeBase):
         # edge_identity_a
         tests.append(
             {
-                "A": torch.eye(4, device="cuda", dtype=dtype),
+                "A": torch.eye(4, device=self.device, dtype=dtype),
                 "B": torch.tensor(
                     [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
-                    device="cuda",
+                    device=self.device,
                     dtype=dtype,
                 ),
-                "C": torch.empty((4, 3), device="cuda", dtype=dtype),
+                "C": torch.empty((4, 3), device=self.device, dtype=dtype),
                 "M": 4,
                 "N": 4,
                 "K": 3,
@@ -157,14 +153,14 @@ class Challenge(ChallengeBase):
 
         # power_of_2_16x16x8
         M, N, K = 16, 16, 8
-        A_dense = torch.empty((M, N), device="cuda", dtype=dtype).uniform_(-2.0, 2.0)
-        mask = torch.rand((M, N), device="cuda") > 0.65
+        A_dense = torch.empty((M, N), device=self.device, dtype=dtype).uniform_(-2.0, 2.0)
+        mask = torch.rand((M, N), device=self.device) > 0.65
         A_sparse = A_dense * mask
         tests.append(
             {
                 "A": A_sparse,
-                "B": torch.empty((N, K), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "C": torch.empty((M, K), device="cuda", dtype=dtype),
+                "B": torch.empty((N, K), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "C": torch.empty((M, K), device=self.device, dtype=dtype),
                 "M": M,
                 "N": N,
                 "K": K,
@@ -174,14 +170,14 @@ class Challenge(ChallengeBase):
 
         # power_of_2_64x32x16
         M, N, K = 64, 32, 16
-        A_dense = torch.empty((M, N), device="cuda", dtype=dtype).uniform_(-3.0, 3.0)
-        mask = torch.rand((M, N), device="cuda") > 0.70
+        A_dense = torch.empty((M, N), device=self.device, dtype=dtype).uniform_(-3.0, 3.0)
+        mask = torch.rand((M, N), device=self.device) > 0.70
         A_sparse = A_dense * mask
         tests.append(
             {
                 "A": A_sparse,
-                "B": torch.empty((N, K), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "C": torch.empty((M, K), device="cuda", dtype=dtype),
+                "B": torch.empty((N, K), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "C": torch.empty((M, K), device=self.device, dtype=dtype),
                 "M": M,
                 "N": N,
                 "K": K,
@@ -191,14 +187,14 @@ class Challenge(ChallengeBase):
 
         # non_power_of_2_negative_values
         M, N, K = 30, 50, 20
-        A_dense = torch.empty((M, N), device="cuda", dtype=dtype).uniform_(-5.0, 5.0)
-        mask = torch.rand((M, N), device="cuda") > 0.65
+        A_dense = torch.empty((M, N), device=self.device, dtype=dtype).uniform_(-5.0, 5.0)
+        mask = torch.rand((M, N), device=self.device) > 0.65
         A_sparse = A_dense * mask
         tests.append(
             {
                 "A": A_sparse,
-                "B": torch.empty((N, K), device="cuda", dtype=dtype).uniform_(-3.0, 3.0),
-                "C": torch.empty((M, K), device="cuda", dtype=dtype),
+                "B": torch.empty((N, K), device=self.device, dtype=dtype).uniform_(-3.0, 3.0),
+                "C": torch.empty((M, K), device=self.device, dtype=dtype),
                 "M": M,
                 "N": N,
                 "K": K,
@@ -208,14 +204,14 @@ class Challenge(ChallengeBase):
 
         # non_power_of_2_255x100x33
         M, N, K = 255, 100, 33
-        A_dense = torch.empty((M, N), device="cuda", dtype=dtype).uniform_(-2.0, 2.0)
-        mask = torch.rand((M, N), device="cuda") > 0.70
+        A_dense = torch.empty((M, N), device=self.device, dtype=dtype).uniform_(-2.0, 2.0)
+        mask = torch.rand((M, N), device=self.device) > 0.70
         A_sparse = A_dense * mask
         tests.append(
             {
                 "A": A_sparse,
-                "B": torch.empty((N, K), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "C": torch.empty((M, K), device="cuda", dtype=dtype),
+                "B": torch.empty((N, K), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "C": torch.empty((M, K), device=self.device, dtype=dtype),
                 "M": M,
                 "N": N,
                 "K": K,
@@ -225,14 +221,14 @@ class Challenge(ChallengeBase):
 
         # realistic_1000x500x64
         M, N, K = 1000, 500, 64
-        A_dense = torch.empty((M, N), device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        mask = torch.rand((M, N), device="cuda") > 0.65
+        A_dense = torch.empty((M, N), device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        mask = torch.rand((M, N), device=self.device) > 0.65
         A_sparse = A_dense * mask
         tests.append(
             {
                 "A": A_sparse,
-                "B": torch.empty((N, K), device="cuda", dtype=dtype).uniform_(-1.0, 1.0),
-                "C": torch.empty((M, K), device="cuda", dtype=dtype),
+                "B": torch.empty((N, K), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "C": torch.empty((M, K), device=self.device, dtype=dtype),
                 "M": M,
                 "N": N,
                 "K": K,
@@ -247,12 +243,12 @@ class Challenge(ChallengeBase):
         M = 4096
         N = 2048
         K = 512
-        A_dense = torch.empty((M, N), device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        mask = torch.rand((M, N), device="cuda") > 0.65
+        A_dense = torch.empty((M, N), device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        mask = torch.rand((M, N), device=self.device) > 0.65
         A_sparse = A_dense * mask
         nnz = int(mask.sum().item())
-        B = torch.empty((N, K), device="cuda", dtype=dtype).uniform_(-1.0, 1.0)
-        C = torch.empty((M, K), device="cuda", dtype=dtype)
+        B = torch.empty((N, K), device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
+        C = torch.empty((M, K), device=self.device, dtype=dtype)
         return {
             "A": A_sparse,
             "B": B,

--- a/challenges/medium/76_adder_transformer/challenge.py
+++ b/challenges/medium/76_adder_transformer/challenge.py
@@ -176,14 +176,11 @@ def _forward_pass(seq: torch.Tensor, weights: torch.Tensor) -> torch.Tensor:
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Adder Transformer Inference",
-            atol=1e-2,
-            rtol=1e-2,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Adder Transformer Inference"
+    atol = 0.01
+    rtol = 0.01
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -194,13 +191,10 @@ class Challenge(ChallengeBase):
     ):
         assert prompts.shape == (batch_size, PROMPT_LEN)
         assert prompts.dtype == torch.int32
-        assert prompts.device.type == "cuda"
         assert output.shape == (batch_size, OUTPUT_DIGITS, VOCAB_SIZE)
         assert output.dtype == torch.float32
-        assert output.device.type == "cuda"
         assert weights.shape == (TOTAL_WEIGHTS,)
         assert weights.dtype == torch.float32
-        assert weights.device.type == "cuda"
 
         seq = prompts.clone()
         for step in range(OUTPUT_DIGITS):
@@ -219,7 +213,7 @@ class Challenge(ChallengeBase):
         }
 
     def generate_example_test(self) -> Dict[str, Any]:
-        device = "cuda"
+        device = self.device
         pairs = [(3, 5), (99, 1)]
         batch_size = len(pairs)
         prompts = torch.tensor(
@@ -239,7 +233,7 @@ class Challenge(ChallengeBase):
         }
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
-        device = "cuda"
+        device = self.device
         tests = []
 
         def _make_test(pairs):
@@ -329,7 +323,7 @@ class Challenge(ChallengeBase):
         return tests
 
     def generate_performance_test(self) -> Dict[str, Any]:
-        device = "cuda"
+        device = self.device
         batch_size = 100000
         torch.manual_seed(123)
         a_vals = torch.randint(0, 10**10, (batch_size,), dtype=torch.int64)

--- a/challenges/medium/78_2d_fft/challenge.py
+++ b/challenges/medium/78_2d_fft/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="2D FFT",
-            atol=1e-02,
-            rtol=1e-02,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "2D FFT"
+    atol = 0.01
+    rtol = 0.01
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(self, signal: torch.Tensor, spectrum: torch.Tensor, M: int, N: int):
         assert signal.shape == (M * N * 2,)
@@ -39,8 +36,10 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         M, N = 2, 2
-        signal = torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], device="cuda", dtype=dtype)
-        spectrum = torch.empty(M * N * 2, device="cuda", dtype=dtype)
+        signal = torch.tensor(
+            [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], device=self.device, dtype=dtype
+        )
+        spectrum = torch.empty(M * N * 2, device=self.device, dtype=dtype)
         return {"signal": signal, "spectrum": spectrum, "M": M, "N": N}
 
     def generate_functional_test(self) -> List[Dict[str, Any]]:
@@ -48,19 +47,19 @@ class Challenge(ChallengeBase):
         cases = []
 
         def make_case(M, N, low=-1.0, high=1.0):
-            signal = torch.empty(M * N * 2, device="cuda", dtype=dtype).uniform_(low, high)
-            spectrum = torch.empty(M * N * 2, device="cuda", dtype=dtype)
+            signal = torch.empty(M * N * 2, device=self.device, dtype=dtype).uniform_(low, high)
+            spectrum = torch.empty(M * N * 2, device=self.device, dtype=dtype)
             return {"signal": signal, "spectrum": spectrum, "M": M, "N": N}
 
         def make_zero_case(M, N):
-            signal = torch.zeros(M * N * 2, device="cuda", dtype=dtype)
-            spectrum = torch.empty(M * N * 2, device="cuda", dtype=dtype)
+            signal = torch.zeros(M * N * 2, device=self.device, dtype=dtype)
+            spectrum = torch.empty(M * N * 2, device=self.device, dtype=dtype)
             return {"signal": signal, "spectrum": spectrum, "M": M, "N": N}
 
         def make_impulse_case(M, N):
-            signal = torch.zeros(M * N * 2, device="cuda", dtype=dtype)
+            signal = torch.zeros(M * N * 2, device=self.device, dtype=dtype)
             signal[0] = 1.0
-            spectrum = torch.empty(M * N * 2, device="cuda", dtype=dtype)
+            spectrum = torch.empty(M * N * 2, device=self.device, dtype=dtype)
             return {"signal": signal, "spectrum": spectrum, "M": M, "N": N}
 
         # Edge cases: small sizes
@@ -88,6 +87,6 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         dtype = torch.float32
         M, N = 2048, 2048
-        signal = torch.empty(M * N * 2, device="cuda", dtype=dtype).normal_(0.0, 1.0)
-        spectrum = torch.empty(M * N * 2, device="cuda", dtype=dtype)
+        signal = torch.empty(M * N * 2, device=self.device, dtype=dtype).normal_(0.0, 1.0)
+        spectrum = torch.empty(M * N * 2, device=self.device, dtype=dtype)
         return {"signal": signal, "spectrum": spectrum, "M": M, "N": N}

--- a/challenges/medium/80_grouped_query_attention/challenge.py
+++ b/challenges/medium/80_grouped_query_attention/challenge.py
@@ -7,14 +7,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Grouped Query Attention",
-            atol=1e-04,
-            rtol=1e-04,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Grouped Query Attention"
+    atol = 0.0001
+    rtol = 0.0001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -32,10 +29,6 @@ class Challenge(ChallengeBase):
         assert V.shape == (num_kv_heads, seq_len, head_dim)
         assert output.shape == (num_q_heads, seq_len, head_dim)
         assert Q.dtype == K.dtype == V.dtype == output.dtype == torch.float32
-        assert Q.device.type == "cuda"
-        assert K.device.type == "cuda"
-        assert V.device.type == "cuda"
-        assert output.device.type == "cuda"
         assert num_q_heads % num_kv_heads == 0
 
         num_groups = num_q_heads // num_kv_heads
@@ -69,7 +62,7 @@ class Challenge(ChallengeBase):
 
     def _make_test_case(self, num_q_heads, num_kv_heads, seq_len, head_dim, zero_inputs=False):
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         if zero_inputs:
             Q = torch.zeros(num_q_heads, seq_len, head_dim, device=device, dtype=dtype)
             K = torch.zeros(num_kv_heads, seq_len, head_dim, device=device, dtype=dtype)
@@ -93,7 +86,7 @@ class Challenge(ChallengeBase):
     def generate_example_test(self) -> Dict[str, Any]:
         torch.manual_seed(0)
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         num_q_heads = 4
         num_kv_heads = 2
         seq_len = 3

--- a/challenges/medium/81_int4_matmul/challenge.py
+++ b/challenges/medium/81_int4_matmul/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="INT4 Weight-Only Quantized MatMul",
-            atol=1e-02,
-            rtol=1e-02,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "INT4 Weight-Only Quantized MatMul"
+    atol = 0.01
+    rtol = 0.01
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -34,10 +31,6 @@ class Challenge(ChallengeBase):
         assert w_q.dtype == torch.uint8
         assert scales.dtype == torch.float16
         assert y.dtype == torch.float16
-        assert x.device.type == "cuda"
-        assert w_q.device.type == "cuda"
-        assert scales.device.type == "cuda"
-        assert y.device.type == "cuda"
 
         # Unpack INT4 weights from packed uint8 bytes.
         # w_q[n, i] stores two weights: w[n, 2*i] in the high nibble (bits 7:4)
@@ -72,7 +65,7 @@ class Challenge(ChallengeBase):
         }
 
     def _make_test_case(self, M: int, N: int, K: int, group_size: int, zero_x: bool = False):
-        device = "cuda"
+        device = self.device
         if zero_x:
             x = torch.zeros(M, K, device=device, dtype=torch.float16)
         else:
@@ -94,7 +87,7 @@ class Challenge(ChallengeBase):
         }
 
     def generate_example_test(self) -> Dict[str, Any]:
-        device = "cuda"
+        device = self.device
         M, N, K, group_size = 2, 4, 4, 2
 
         x = torch.tensor(

--- a/challenges/medium/82_linear_recurrence/challenge.py
+++ b/challenges/medium/82_linear_recurrence/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Linear Recurrence",
-            atol=1e-05,
-            rtol=1e-05,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Linear Recurrence"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -27,9 +24,6 @@ class Challenge(ChallengeBase):
         assert x.shape == (B, L)
         assert h.shape == (B, L)
         assert a.dtype == x.dtype == h.dtype == torch.float32
-        assert a.device.type == "cuda"
-        assert x.device.type == "cuda"
-        assert h.device.type == "cuda"
 
         out = torch.empty_like(x)
         out[:, 0] = x[:, 0]
@@ -47,7 +41,7 @@ class Challenge(ChallengeBase):
         }
 
     def _make_test_case(self, B, L, zero_inputs=False, zero_a=False, unit_a=False):
-        device = "cuda"
+        device = self.device
         dtype = torch.float32
         if zero_inputs:
             a = torch.zeros(B, L, device=device, dtype=dtype)
@@ -65,7 +59,7 @@ class Challenge(ChallengeBase):
         return {"a": a, "x": x, "h": h, "B": B, "L": L}
 
     def generate_example_test(self) -> Dict[str, Any]:
-        device = "cuda"
+        device = self.device
         dtype = torch.float32
         a = torch.tensor(
             [[0.5, 0.5, 0.5, 0.5], [1.0, 1.0, 1.0, 1.0]],

--- a/challenges/medium/84_swiglu_mlp_block/challenge.py
+++ b/challenges/medium/84_swiglu_mlp_block/challenge.py
@@ -7,14 +7,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="SwiGLU MLP Block",
-            atol=1e-04,
-            rtol=1e-04,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "SwiGLU MLP Block"
+    atol = 0.0001
+    rtol = 0.0001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -35,11 +32,6 @@ class Challenge(ChallengeBase):
         assert (
             x.dtype == W_gate.dtype == W_up.dtype == W_down.dtype == output.dtype == torch.float32
         )
-        assert x.device.type == "cuda"
-        assert W_gate.device.type == "cuda"
-        assert W_up.device.type == "cuda"
-        assert W_down.device.type == "cuda"
-        assert output.device.type == "cuda"
 
         gate = x @ W_gate  # [M, d_ffn]
         up = x @ W_up  # [M, d_ffn]
@@ -59,7 +51,7 @@ class Challenge(ChallengeBase):
         }
 
     def _make_test_case(self, M, d_model, d_ffn, zero_x=False):
-        device = "cuda"
+        device = self.device
         dtype = torch.float32
         if zero_x:
             x = torch.zeros(M, d_model, device=device, dtype=dtype)
@@ -81,7 +73,7 @@ class Challenge(ChallengeBase):
         }
 
     def generate_example_test(self) -> Dict[str, Any]:
-        device = "cuda"
+        device = self.device
         dtype = torch.float32
         M, d_model, d_ffn = 2, 2, 4
         # x: each row is a basis vector

--- a/challenges/medium/85_lora_linear/challenge.py
+++ b/challenges/medium/85_lora_linear/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="LoRA Linear",
-            atol=1e-04,
-            rtol=1e-04,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "LoRA Linear"
+    atol = 0.0001
+    rtol = 0.0001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -34,11 +31,6 @@ class Challenge(ChallengeBase):
         assert B.shape == (d_out, rank)
         assert output.shape == (batch, d_out)
         assert x.dtype == W.dtype == A.dtype == B.dtype == output.dtype == torch.float32
-        assert x.device.type == "cuda"
-        assert W.device.type == "cuda"
-        assert A.device.type == "cuda"
-        assert B.device.type == "cuda"
-        assert output.device.type == "cuda"
 
         # Base linear: output = x @ W^T
         base = torch.mm(x, W.t())
@@ -65,7 +57,7 @@ class Challenge(ChallengeBase):
 
     def _make_test_case(self, batch, d_in, d_out, rank, lora_scale=0.5, zero_x=False):
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         if zero_x:
             x = torch.zeros(batch, d_in, device=device, dtype=dtype)
         else:
@@ -89,7 +81,7 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         x = torch.tensor([[1.0, 0.0, -1.0, 2.0], [0.0, 1.0, 1.0, -1.0]], device=device, dtype=dtype)
         W = torch.tensor(
             [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]],
@@ -147,11 +139,11 @@ class Challenge(ChallengeBase):
         # Negative inputs
         tests.append(
             {
-                "x": torch.full((4, 32), -1.0, device="cuda", dtype=torch.float32),
-                "W": torch.randn(32, 32, device="cuda", dtype=torch.float32) * 0.02,
-                "A": torch.randn(8, 32, device="cuda", dtype=torch.float32) * 0.02,
-                "B": torch.randn(32, 8, device="cuda", dtype=torch.float32) * 0.02,
-                "output": torch.zeros(4, 32, device="cuda", dtype=torch.float32),
+                "x": torch.full((4, 32), -1.0, device=self.device, dtype=torch.float32),
+                "W": torch.randn(32, 32, device=self.device, dtype=torch.float32) * 0.02,
+                "A": torch.randn(8, 32, device=self.device, dtype=torch.float32) * 0.02,
+                "B": torch.randn(32, 8, device=self.device, dtype=torch.float32) * 0.02,
+                "output": torch.zeros(4, 32, device=self.device, dtype=torch.float32),
                 "batch": 4,
                 "d_in": 32,
                 "d_out": 32,

--- a/challenges/medium/87_speculative_decoding_verification/challenge.py
+++ b/challenges/medium/87_speculative_decoding_verification/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Speculative Decoding Verification",
-            atol=1e-05,
-            rtol=1e-05,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Speculative Decoding Verification"
+    atol = 1e-05
+    rtol = 1e-05
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -36,11 +33,6 @@ class Challenge(ChallengeBase):
         assert target_probs.dtype == torch.float32
         assert uniform_samples.dtype == torch.float32
         assert output_tokens.dtype == torch.int32
-        assert draft_tokens.device.type == "cuda"
-        assert draft_probs.device.type == "cuda"
-        assert target_probs.device.type == "cuda"
-        assert uniform_samples.device.type == "cuda"
-        assert output_tokens.device.type == "cuda"
 
         output_tokens.fill_(0)
 
@@ -107,7 +99,7 @@ class Challenge(ChallengeBase):
 
     def _make_test_case(self, B, T, V, seed=42):
         torch.manual_seed(seed)
-        device = "cuda"
+        device = self.device
 
         # K=64 active tokens per position: enough diversity while keeping the adjusted
         # distribution sparse (at most 128 nonzero entries), ensuring CDF sums are
@@ -139,7 +131,7 @@ class Challenge(ChallengeBase):
     def _make_accept_all_case(self, B, T, V, seed=42):
         """All draft tokens accepted: target_probs == draft_probs so alpha == 1 everywhere."""
         torch.manual_seed(seed)
-        device = "cuda"
+        device = self.device
 
         K = min(64, V)
         draft_probs, draft_idx = self._make_sparse_probs(B, T, V, K, device)
@@ -170,7 +162,7 @@ class Challenge(ChallengeBase):
     def _make_reject_first_case(self, B, T, V, seed=42):
         """First draft token always rejected: draft_probs high, target low for that token."""
         torch.manual_seed(seed)
-        device = "cuda"
+        device = self.device
 
         draft_probs = torch.softmax(torch.randn(B, T, V, device=device), dim=-1)
         target_probs = torch.softmax(torch.randn(B, T, V, device=device), dim=-1)
@@ -207,7 +199,7 @@ class Challenge(ChallengeBase):
         }
 
     def generate_example_test(self) -> Dict[str, Any]:
-        device = "cuda"
+        device = self.device
 
         # B=1, T=3, V=4: position 0 accepted, position 1 rejected, token resampled
         draft_tokens = torch.tensor([[1, 2, 0]], device=device, dtype=torch.int32)

--- a/challenges/medium/87_speculative_decoding_verification/starter/starter.mojo
+++ b/challenges/medium/87_speculative_decoding_verification/starter/starter.mojo
@@ -1,6 +1,7 @@
 from gpu.host import DeviceContext
 from memory import UnsafePointer
 
+
 # draft_tokens, draft_probs, target_probs, uniform_samples, output_tokens are device pointers
 @export
 def solve(

--- a/challenges/medium/90_causal_depthwise_conv1d/challenge.py
+++ b/challenges/medium/90_causal_depthwise_conv1d/challenge.py
@@ -7,14 +7,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Causal Depthwise Conv1d",
-            atol=1e-04,
-            rtol=1e-04,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Causal Depthwise Conv1d"
+    atol = 0.0001
+    rtol = 0.0001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -32,10 +29,6 @@ class Challenge(ChallengeBase):
         assert bias.shape == (D,)
         assert output.shape == (B, L, D)
         assert x.dtype == weight.dtype == bias.dtype == output.dtype == torch.float32
-        assert x.device.type == "cuda"
-        assert weight.device.type == "cuda"
-        assert bias.device.type == "cuda"
-        assert output.device.type == "cuda"
 
         # Reshape to (B, D, L) for conv1d
         x_t = x.permute(0, 2, 1).contiguous()  # (B, D, L)
@@ -69,14 +62,14 @@ class Challenge(ChallengeBase):
         B, L, D, K = 1, 4, 2, 3
         x = torch.tensor(
             [[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]],
-            device="cuda",
+            device=self.device,
             dtype=torch.float32,
         )
         weight = torch.tensor(
-            [[1.0, 0.0, -1.0], [1.0, 1.0, 1.0]], device="cuda", dtype=torch.float32
+            [[1.0, 0.0, -1.0], [1.0, 1.0, 1.0]], device=self.device, dtype=torch.float32
         )
-        bias = torch.zeros(D, device="cuda", dtype=torch.float32)
-        output = torch.empty(B, L, D, device="cuda", dtype=torch.float32)
+        bias = torch.zeros(D, device=self.device, dtype=torch.float32)
+        output = torch.empty(B, L, D, device=self.device, dtype=torch.float32)
         return {
             "x": x,
             "weight": weight,
@@ -94,18 +87,18 @@ class Challenge(ChallengeBase):
 
         def make_case(B, L, D, K, x_vals=None, w_vals=None, b_vals=None):
             if x_vals is not None:
-                x = torch.tensor(x_vals, device="cuda", dtype=dtype)
+                x = torch.tensor(x_vals, device=self.device, dtype=dtype)
             else:
-                x = torch.randn(B, L, D, device="cuda", dtype=dtype)
+                x = torch.randn(B, L, D, device=self.device, dtype=dtype)
             if w_vals is not None:
-                weight = torch.tensor(w_vals, device="cuda", dtype=dtype)
+                weight = torch.tensor(w_vals, device=self.device, dtype=dtype)
             else:
-                weight = torch.randn(D, K, device="cuda", dtype=dtype)
+                weight = torch.randn(D, K, device=self.device, dtype=dtype)
             if b_vals is not None:
-                bias = torch.tensor(b_vals, device="cuda", dtype=dtype)
+                bias = torch.tensor(b_vals, device=self.device, dtype=dtype)
             else:
-                bias = torch.randn(D, device="cuda", dtype=dtype)
-            output = torch.empty(B, L, D, device="cuda", dtype=dtype)
+                bias = torch.randn(D, device=self.device, dtype=dtype)
+            output = torch.empty(B, L, D, device=self.device, dtype=dtype)
             return {
                 "x": x,
                 "weight": weight,
@@ -136,15 +129,15 @@ class Challenge(ChallengeBase):
         test_cases.append(make_case(2, 3, 4, 3))  # small batch, B=2
 
         # Zero inputs
-        x_zero = torch.zeros(1, 8, 4, device="cuda", dtype=dtype)
-        w_zero = torch.randn(4, 3, device="cuda", dtype=dtype)
-        b_zero = torch.randn(4, device="cuda", dtype=dtype)
+        x_zero = torch.zeros(1, 8, 4, device=self.device, dtype=dtype)
+        w_zero = torch.randn(4, 3, device=self.device, dtype=dtype)
+        b_zero = torch.randn(4, device=self.device, dtype=dtype)
         test_cases.append(
             {
                 "x": x_zero,
                 "weight": w_zero,
                 "bias": b_zero,
-                "output": torch.empty(1, 8, 4, device="cuda", dtype=dtype),
+                "output": torch.empty(1, 8, 4, device=self.device, dtype=dtype),
                 "B": 1,
                 "L": 8,
                 "D": 4,
@@ -171,10 +164,10 @@ class Challenge(ChallengeBase):
     def generate_performance_test(self) -> Dict[str, Any]:
         B, L, D, K = 8, 2048, 4096, 4
         dtype = torch.float32
-        x = torch.randn(B, L, D, device="cuda", dtype=dtype)
-        weight = torch.randn(D, K, device="cuda", dtype=dtype)
-        bias = torch.randn(D, device="cuda", dtype=dtype)
-        output = torch.empty(B, L, D, device="cuda", dtype=dtype)
+        x = torch.randn(B, L, D, device=self.device, dtype=dtype)
+        weight = torch.randn(D, K, device=self.device, dtype=dtype)
+        bias = torch.randn(D, device=self.device, dtype=dtype)
+        output = torch.empty(B, L, D, device=self.device, dtype=dtype)
         return {
             "x": x,
             "weight": weight,

--- a/challenges/medium/90_causal_depthwise_conv1d/starter/starter.mojo
+++ b/challenges/medium/90_causal_depthwise_conv1d/starter/starter.mojo
@@ -1,6 +1,7 @@
 from gpu.host import DeviceContext
 from memory import UnsafePointer
 
+
 # x, weight, bias, output are device pointers
 @export
 def solve(

--- a/challenges/medium/92_decaying_causal_attention/challenge.py
+++ b/challenges/medium/92_decaying_causal_attention/challenge.py
@@ -7,14 +7,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="Decaying Causal Attention",
-            atol=1e-03,
-            rtol=1e-03,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "Decaying Causal Attention"
+    atol = 0.001
+    rtol = 0.001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -31,10 +28,6 @@ class Challenge(ChallengeBase):
         assert V.shape == (seq_len, d_model)
         assert output.shape == (seq_len, d_model)
         assert Q.dtype == K.dtype == V.dtype == output.dtype == torch.float32
-        assert Q.device.type == "cuda"
-        assert K.device.type == "cuda"
-        assert V.device.type == "cuda"
-        assert output.device.type == "cuda"
 
         scale = math.sqrt(d_model)
         positions = torch.arange(seq_len, device=Q.device, dtype=Q.dtype)
@@ -59,7 +52,7 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         # Orthogonal K rows → QK^T / sqrt(4) = [[0.5, 0.5], [0.5, 0.5]].
         # With gamma=0.5 decay mask [[1, 0], [0.5, 1]], weighted attn = [[0.5, 0], [0.25, 0.5]].
         # Output row 0 = 0.5 * V[0]; row 1 = 0.25 * V[0] + 0.5 * V[1] = [3, 6, 9, 12].
@@ -80,7 +73,7 @@ class Challenge(ChallengeBase):
         negative: bool = False,
     ) -> Dict[str, Any]:
         dtype = torch.float32
-        device = "cuda"
+        device = self.device
         if zero_qk:
             Q = torch.zeros(seq_len, d_model, device=device, dtype=dtype)
             K = torch.zeros(seq_len, d_model, device=device, dtype=dtype)

--- a/challenges/medium/94_ssm_selective_scan/challenge.py
+++ b/challenges/medium/94_ssm_selective_scan/challenge.py
@@ -6,14 +6,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="SSM Selective Scan",
-            atol=1e-03,
-            rtol=1e-03,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "SSM Selective Scan"
+    atol = 0.001
+    rtol = 0.001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -39,13 +36,6 @@ class Challenge(ChallengeBase):
         assert (
             u.dtype == delta.dtype == A.dtype == B.dtype == C.dtype == skip.dtype == torch.float32
         )
-        assert u.device.type == "cuda"
-        assert delta.device.type == "cuda"
-        assert A.device.type == "cuda"
-        assert B.device.type == "cuda"
-        assert C.device.type == "cuda"
-        assert skip.device.type == "cuda"
-        assert y.device.type == "cuda"
 
         # Hidden state: (batch, d_model, d_state)
         h = torch.zeros(batch, d_model, d_state, device=u.device, dtype=u.dtype)
@@ -88,7 +78,7 @@ class Challenge(ChallengeBase):
         }
 
     def _make_test_case(self, batch, seq_len, d_model, d_state, zero_u=False, zero_delta=False):
-        device = "cuda"
+        device = self.device
         dtype = torch.float32
         if zero_u:
             u = torch.zeros(batch, seq_len, d_model, device=device, dtype=dtype)
@@ -121,7 +111,7 @@ class Challenge(ChallengeBase):
 
     def generate_example_test(self) -> Dict[str, Any]:
         torch.manual_seed(0)
-        device = "cuda"
+        device = self.device
         dtype = torch.float32
         batch, seq_len, d_model, d_state = 1, 4, 2, 2
         u = torch.tensor(

--- a/challenges/medium/96_int8_kv_cache_attention/challenge.py
+++ b/challenges/medium/96_int8_kv_cache_attention/challenge.py
@@ -7,14 +7,11 @@ from core.challenge_base import ChallengeBase
 
 
 class Challenge(ChallengeBase):
-    def __init__(self):
-        super().__init__(
-            name="INT8 KV-Cache Attention",
-            atol=1e-03,
-            rtol=1e-03,
-            num_gpus=1,
-            access_tier="free",
-        )
+    name = "INT8 KV-Cache Attention"
+    atol = 0.001
+    rtol = 0.001
+    num_gpus = 1
+    access_tier = "free"
 
     def reference_impl(
         self,
@@ -40,12 +37,6 @@ class Challenge(ChallengeBase):
         assert k_scale.dtype == torch.float32
         assert v_scale.dtype == torch.float32
         assert output.dtype == torch.float32
-        assert Q.device.type == "cuda"
-        assert K_int8.device.type == "cuda"
-        assert V_int8.device.type == "cuda"
-        assert k_scale.device.type == "cuda"
-        assert v_scale.device.type == "cuda"
-        assert output.device.type == "cuda"
 
         # Dequantize: K_float[h, s, d] = K_int8[h, s, d] * k_scale[h, s]
         K_float = K_int8.float() * k_scale.unsqueeze(-1)  # [num_heads, seq_len, head_dim]
@@ -75,7 +66,7 @@ class Challenge(ChallengeBase):
         }
 
     def _make_test_case(self, num_heads, seq_len, head_dim, zero_q=False, seed=None):
-        device = "cuda"
+        device = self.device
         if seed is not None:
             torch.manual_seed(seed)
         if zero_q:
@@ -104,7 +95,7 @@ class Challenge(ChallengeBase):
         }
 
     def generate_example_test(self) -> Dict[str, Any]:
-        device = "cuda"
+        device = self.device
         num_heads, seq_len, head_dim = 1, 3, 4
         Q = torch.tensor([[1.0, 1.0, 1.0, 1.0]], dtype=torch.float32, device=device)
         K_int8 = torch.tensor(


### PR DESCRIPTION
## Summary
- `ChallengeBase.__init__` now takes only `device` (default `"cuda"`); `name/atol/rtol/num_gpus/access_tier` are declared on `ChallengeBase` as type-annotated class attributes.
- **All 88 `Challenge` subclasses lose `__init__` entirely** — metadata becomes class attributes:
  ```python
  class Challenge(ChallengeBase):
      name = "Vector Addition"
      atol = 1e-05
      rtol = 1e-05
      num_gpus = 1
      access_tier = "free"
      def reference_impl(...): ...
  ```
- `device="cuda"` literals in `generate_*_test` methods → `self.device`.
- Dropped 72 CUDA-specific `assert X.device.type == "cuda"` / `.is_cuda` invariant checks (across 22 files). Downstream ops surface device mismatch loudly on their own.
- Threaded `device` through the module-level `_make_graph` helper in `73_all_pairs_shortest_paths`.

## Why
The TPU runner currently uses a global torch monkey-patch to redirect `device="cuda"` to CPU. That forces the reference impl onto CPU, which is too slow for the transformer/quantized/attention cluster (llama_transformer_block, gpt2_block, int8_kv_cache_attention, int4_matmul, swiglu_mlp_block, etc.). Threading `device` lets the TPU runner do `Challenge(device=str(xm.xla_device()))` and run the reference on TPU directly — no monkey-patching, no shim.

Class-attribute metadata is the right shape because no subclass had real init logic — they were 88 copies of forwarding boilerplate.

## Test plan
- [x] AST-validate all 88 `challenge.py` files
- [x] Instantiate all 88 with default (`device="cuda"`) — no allocation triggered
- [x] Instantiate all 88 with `device="cpu"`, run `generate_example_test()` + `reference_impl()` end-to-end (3 deterministic runs) — 88/88 pass
- [x] Pre-commit hooks pass (black, isort, flake8)
- [ ] CUDA path smoke test (existing CUDA runner still works against this branch)
- [ ] TPU path smoke test (1_vector_add via the updated tpu_runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)