### PR TITLE
Rename gpu to accelerator in deploy/run scripts

### DIFF
--- a/scripts/run_challenge.py
+++ b/scripts/run_challenge.py
@@ -51,7 +51,7 @@ def submit_solution(
     file_name: str,
     content: str,
     language: str,
-    gpu: str,
+    accelerator: str,
     action: str,
     public: bool,
 ) -> bool:
@@ -64,7 +64,7 @@ def submit_solution(
             "submission": {
                 "files": [{"name": file_name, "content": content}],
                 "language": language,
-                "gpu": gpu,
+                "accelerator": accelerator,
                 "mode": "accelerated",
                 "public": public,
                 "challengeCode": challenge_code,
@@ -95,7 +95,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Submit a solution via WebSocket API.")
     parser.add_argument("challenge_path", type=Path, help="Path to the challenge directory")
     parser.add_argument("--language", default="cuda", help="Language (default: cuda)")
-    parser.add_argument("--gpu", default="T4", help="GPU name (default: T4)")
+    parser.add_argument("--accelerator", default="T4", help="Accelerator name (default: T4)")
     parser.add_argument(
         "--action", default="run", choices=["run", "submit"], help="Action (run or submit)"
     )
@@ -122,7 +122,7 @@ def main() -> int:
         file_name=file_name,
         content=content,
         language=args.language,
-        gpu=args.gpu,
+        accelerator=args.accelerator,
         action=args.action,
         public=False,
     )

--- a/scripts/update_challenges.py
+++ b/scripts/update_challenges.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 SERVICE_URL = os.getenv("SERVICE_URL", "http://localhost:8080")
 LEETGPU_API_KEY = os.getenv("LEETGPU_API_KEY")
 
-GPUS = ["H100", "H200", "T4", "B200", "A100-80GB"]
+ACCELERATORS = ["H100", "H200", "T4", "B200", "A100-80GB"]
 
 
 def extract_id(name: str) -> int:
@@ -120,7 +120,7 @@ def load_challenge(problem_dir: Path) -> Dict:
         "challengeCode": challenge_path.read_text(),
         "difficultyLevel": get_difficulty(problem_dir),
         "accessTier": access_tier,
-        "gpus": GPUS,  # TODO: get from challenge.py or API
+        "accelerators": ACCELERATORS,  # TODO: get from challenge.py or API
         "starterCode": starter_code,
     }
 


### PR DESCRIPTION
## Summary
- Match leetgpu-infra's `Accelerator` / `Accelerators` API by renaming `--gpu` → `--accelerator` in `run_challenge.py` and `GPUS`/`"gpus"` → `ACCELERATORS`/`"accelerators"` in `update_challenges.py`.

## Test plan
- [ ] `python scripts/run_challenge.py path/to/challenge --accelerator T4 --action run` submits successfully against a running infra service
- [ ] `python scripts/update_challenges.py path/to/challenge` upserts a challenge successfully against a running infra service

🤖 Generated with [Claude Code](https://claude.com/claude-code)