### PR TITLE
Enforce half-split layout for cos/sin in RoPE challenge test data

### DIFF
--- a/challenges/medium/61_rope_embedding/challenge.html
+++ b/challenges/medium/61_rope_embedding/challenge.html
@@ -19,6 +19,7 @@
     <li>External libraries are not permitted</li>
     <li>The <code>solve</code> function signature must remain unchanged</li>
     <li>The input tensors <code>Q</code>, <code>cos</code>, and <code>sin</code> have shape <code>(M, D)</code>, where <code>M</code> is the number of tokens and <code>D</code> is the head dimension</li>
+    <li><code>cos</code> and <code>sin</code> use half-split layout: values at dimensions <code>j</code> and <code>j + D/2</code> are identical for each row</li>
     <li><code>D</code> (head dimension) is guaranteed to be an even number</li>
     <li>The final result must be stored in the output variable with the same shape <code>(M, D)</code></li>
 </ul>

--- a/challenges/medium/61_rope_embedding/challenge.py
+++ b/challenges/medium/61_rope_embedding/challenge.py
@@ -49,14 +49,18 @@ class Challenge(ChallengeBase):
             "D": (ctypes.c_int, "in"),
         }
 
+    def _enforce_half_split(self, table: torch.Tensor, D: int):
+        table[:, D // 2 :] = table[:, : D // 2]
+        return table
+
     def generate_example_test(self) -> Dict[str, Any]:
         M = 1024
         D = 64
         dtype = torch.float32
 
         Q = torch.randn(M, D, device=self.device, dtype=dtype)
-        Cos = torch.randn(M, D, device=self.device, dtype=dtype)
-        Sin = torch.randn(M, D, device=self.device, dtype=dtype)
+        Cos = self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D)
+        Sin = self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D)
         Output = torch.zeros(M, D, device=self.device, dtype=dtype)
 
         return {
@@ -78,8 +82,8 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "Q": torch.randn(M, D, device=self.device, dtype=dtype),
-                "cos": torch.randn(M, D, device=self.device, dtype=dtype),
-                "sin": torch.randn(M, D, device=self.device, dtype=dtype),
+                "cos": self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D),
+                "sin": self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D),
                 "output": torch.zeros(M, D, device=self.device, dtype=dtype),
                 "M": M,
                 "D": D,
@@ -92,8 +96,8 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "Q": torch.randn(M, D, device=self.device, dtype=dtype),
-                "cos": torch.randn(M, D, device=self.device, dtype=dtype),
-                "sin": torch.randn(M, D, device=self.device, dtype=dtype),
+                "cos": self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D),
+                "sin": self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D),
                 "output": torch.zeros(M, D, device=self.device, dtype=dtype),
                 "M": M,
                 "D": D,
@@ -116,8 +120,8 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "Q": torch.randn((1, 2), device=self.device, dtype=dtype),
-                "cos": torch.randn((1, 2), device=self.device, dtype=dtype),
-                "sin": torch.randn((1, 2), device=self.device, dtype=dtype),
+                "cos": self._enforce_half_split(torch.randn((1, 2), device=self.device, dtype=dtype), 2),
+                "sin": self._enforce_half_split(torch.randn((1, 2), device=self.device, dtype=dtype), 2),
                 "output": torch.zeros(1, 2, device=self.device, dtype=dtype),
                 "M": 1,
                 "D": 2,
@@ -133,12 +137,12 @@ class Challenge(ChallengeBase):
                     dtype=dtype,
                 ),
                 "cos": torch.tensor(
-                    [[0.5, 0.5, 0.5, 0.5], [0.1, 0.2, 0.3, 0.4]],
+                    [[0.5, 0.5, 0.5, 0.5], [0.1, 0.2, 0.1, 0.2]],
                     device=self.device,
                     dtype=dtype,
                 ),
                 "sin": torch.tensor(
-                    [[0.5, -0.5, 0.5, -0.5], [0.4, -0.3, 0.2, -0.1]],
+                    [[0.5, -0.5, 0.5, -0.5], [0.4, -0.3, 0.4, -0.3]],
                     device=self.device,
                     dtype=dtype,
                 ),
@@ -152,8 +156,12 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "Q": torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
-                "cos": torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
-                "sin": torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-1.0, 1.0),
+                "cos": self._enforce_half_split(
+                    torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-1.0, 1.0), 128
+                ),
+                "sin": self._enforce_half_split(
+                    torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-1.0, 1.0), 128
+                ),
                 "output": torch.zeros(256, 128, device=self.device, dtype=dtype),
                 "M": 256,
                 "D": 128,
@@ -168,8 +176,8 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         return {
             "Q": torch.randn(M, D, device=self.device, dtype=dtype),
-            "cos": torch.randn(M, D, device=self.device, dtype=dtype),
-            "sin": torch.randn(M, D, device=self.device, dtype=dtype),
+            "cos": self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D),
+            "sin": self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D),
             "output": torch.zeros(M, D, device=self.device, dtype=dtype),
             "M": M,
             "D": D,

--- a/challenges/medium/61_rope_embedding/challenge.py
+++ b/challenges/medium/61_rope_embedding/challenge.py
@@ -49,7 +49,8 @@ class Challenge(ChallengeBase):
             "D": (ctypes.c_int, "in"),
         }
 
-    def _enforce_half_split(self, table: torch.Tensor, D: int):
+    def _half_split(self, table: torch.Tensor) -> torch.Tensor:
+        D = table.shape[1]
         table[:, D // 2 :] = table[:, : D // 2]
         return table
 
@@ -59,8 +60,8 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
 
         Q = torch.randn(M, D, device=self.device, dtype=dtype)
-        Cos = self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D)
-        Sin = self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D)
+        Cos = self._half_split(torch.randn(M, D, device=self.device, dtype=dtype))
+        Sin = self._half_split(torch.randn(M, D, device=self.device, dtype=dtype))
         Output = torch.zeros(M, D, device=self.device, dtype=dtype)
 
         return {
@@ -82,8 +83,8 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "Q": torch.randn(M, D, device=self.device, dtype=dtype),
-                "cos": self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D),
-                "sin": self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D),
+                "cos": self._half_split(torch.randn(M, D, device=self.device, dtype=dtype)),
+                "sin": self._half_split(torch.randn(M, D, device=self.device, dtype=dtype)),
                 "output": torch.zeros(M, D, device=self.device, dtype=dtype),
                 "M": M,
                 "D": D,
@@ -96,8 +97,8 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "Q": torch.randn(M, D, device=self.device, dtype=dtype),
-                "cos": self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D),
-                "sin": self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D),
+                "cos": self._half_split(torch.randn(M, D, device=self.device, dtype=dtype)),
+                "sin": self._half_split(torch.randn(M, D, device=self.device, dtype=dtype)),
                 "output": torch.zeros(M, D, device=self.device, dtype=dtype),
                 "M": M,
                 "D": D,
@@ -120,8 +121,8 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "Q": torch.randn((1, 2), device=self.device, dtype=dtype),
-                "cos": self._enforce_half_split(torch.randn((1, 2), device=self.device, dtype=dtype), 2),
-                "sin": self._enforce_half_split(torch.randn((1, 2), device=self.device, dtype=dtype), 2),
+                "cos": self._half_split(torch.randn((1, 2), device=self.device, dtype=dtype)),
+                "sin": self._half_split(torch.randn((1, 2), device=self.device, dtype=dtype)),
                 "output": torch.zeros(1, 2, device=self.device, dtype=dtype),
                 "M": 1,
                 "D": 2,
@@ -156,11 +157,11 @@ class Challenge(ChallengeBase):
         tests.append(
             {
                 "Q": torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-0.1, 0.1),
-                "cos": self._enforce_half_split(
-                    torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-1.0, 1.0), 128
+                "cos": self._half_split(
+                    torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
                 ),
-                "sin": self._enforce_half_split(
-                    torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-1.0, 1.0), 128
+                "sin": self._half_split(
+                    torch.empty((256, 128), device=self.device, dtype=dtype).uniform_(-1.0, 1.0)
                 ),
                 "output": torch.zeros(256, 128, device=self.device, dtype=dtype),
                 "M": 256,
@@ -176,8 +177,8 @@ class Challenge(ChallengeBase):
         dtype = torch.float32
         return {
             "Q": torch.randn(M, D, device=self.device, dtype=dtype),
-            "cos": self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D),
-            "sin": self._enforce_half_split(torch.randn(M, D, device=self.device, dtype=dtype), D),
+            "cos": self._half_split(torch.randn(M, D, device=self.device, dtype=dtype)),
+            "sin": self._half_split(torch.randn(M, D, device=self.device, dtype=dtype)),
             "output": torch.zeros(M, D, device=self.device, dtype=dtype),
             "M": M,
             "D": D,


### PR DESCRIPTION
## Summary
Fixes the RoPE challenge test data so `cos` and `sin` follow the half-split layout described by the problem.
For RoPE with `rotate_half`, paired dimensions `j` and `j + D/2` should use the same cosine and sine values. Previously, several generated test cases used fully independent random values for all `D` dimensions, so `cos[:, j] != cos[:, j + D/2]` and `sin[:, j] != sin[:, j + D/2]` in general.
This PR keeps the existing random data generation style unchanged and only enforces:
```python
value[:, D // 2 :] = value[:, : D // 2]
```
## Changes
- Added a small helper to enforce half-split layout for generated `cos` and `sin` tables.
- Updated generated RoPE test inputs so paired dimensions share the same `cos` / `sin` values.
- Updated the fixed `mixed_values` test case to satisfy the same layout.
- Documented the half-split `cos` / `sin` requirement in the challenge description.
## Motivation
The current random `cos` / `sin` test data prevents implementations from using the standard half-split RoPE assumption that paired dimensions share the same rotation values. This makes the test data inconsistent with the expected RoPE layout and forces extra `cos` / `sin` loads that should not be necessary for this formulation.
## Testing
- `python3 -m py_compile challenges/medium/61_rope_embedding/challenge.py`
- `git diff --check -- challenges/medium/61_rope_embedding/challenge.py challenges/medium/61_rope_embedding/challenge.html`