### PR TITLE
Use 'tensors on device' wording in JAX starters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ Each starter file must have exactly one comment describing the parameters, place
 | CUDA | `// <params> are device pointers` |
 | Mojo | `# <params> are device pointers` |
 | PyTorch, Triton, CuTe | `# <params> are tensors on the GPU` |
-| JAX | `# <params> are tensors on GPU` (+ `# return output tensor directly` inside body) |
+| JAX | `# <params> are tensors on device` (+ `# return output tensor directly` inside body) |
 
 **Rules:**
 - Easy challenges: include the parenthetical `(i.e. pointers to memory on the GPU)` for CUDA/Mojo (matches vector_add reference)
@@ -200,7 +200,7 @@ Verify every item before submitting. This is the single source of truth — work
 - [ ] All 6 files present: `.cu`, `.pytorch.py`, `.triton.py`, `.jax.py`, `.cute.py`, `.mojo`
 - [ ] Exactly 1 parameter description comment per file, no other comments
 - [ ] CUDA/Mojo use "device pointers"; easy challenges include `(i.e. pointers to memory on the GPU)`, medium/hard omit it
-- [ ] Python frameworks use "tensors on the GPU"; JAX also has `# return output tensor directly`
+- [ ] PyTorch/Triton/CuTe use "tensors on the GPU"; JAX uses "tensors on device" and also has `# return output tensor directly`
 - [ ] Starters compile/run but do NOT produce correct output
 
 ### General

--- a/challenges/easy/19_reverse_array/starter/starter.jax.py
+++ b/challenges/easy/19_reverse_array/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/1_vector_add/starter/starter.jax.py
+++ b/challenges/easy/1_vector_add/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A, B are tensors on GPU
+# A, B are tensors on device
 @jax.jit
 def solve(A: jax.Array, B: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/21_relu/starter/starter.jax.py
+++ b/challenges/easy/21_relu/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/23_leaky_relu/starter/starter.jax.py
+++ b/challenges/easy/23_leaky_relu/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/24_rainbow_table/starter/starter.jax.py
+++ b/challenges/easy/24_rainbow_table/starter/starter.jax.py
@@ -16,7 +16,7 @@ def fnv1a_hash(x: jax.Array) -> jax.Array:
     return hash_val
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 def solve(input: jax.Array, N: int, R: int) -> jax.Array:
     # return output tensor directly
     pass

--- a/challenges/easy/2_matrix_multiplication/starter/starter.jax.py
+++ b/challenges/easy/2_matrix_multiplication/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A, B are tensors on GPU
+# A, B are tensors on device
 @jax.jit
 def solve(A: jax.Array, B: jax.Array, M: int, N: int, K: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/31_matrix_copy/starter/starter.jax.py
+++ b/challenges/easy/31_matrix_copy/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A is a tensor on the GPU
+# A is a tensor on device
 @jax.jit
 def solve(A: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/3_matrix_transpose/starter/starter.jax.py
+++ b/challenges/easy/3_matrix_transpose/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, rows: int, cols: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/41_simple_inference/starter/starter.jax.py
+++ b/challenges/easy/41_simple_inference/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input and model are on the GPU
+# input and model are on device
 def solve(input: jax.Array, model) -> jax.Array:
     # return output tensor directly
     pass

--- a/challenges/easy/52_silu/starter/starter.jax.py
+++ b/challenges/easy/52_silu/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/54_swiglu/starter/starter.jax.py
+++ b/challenges/easy/54_swiglu/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/62_value_clipping/starter/starter.jax.py
+++ b/challenges/easy/62_value_clipping/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, lo: float, hi: float, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/63_interleave/starter/starter.jax.py
+++ b/challenges/easy/63_interleave/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A, B are tensors on the GPU
+# A, B are tensors on device
 @jax.jit
 def solve(A: jax.Array, B: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/65_geglu/starter/starter.jax.py
+++ b/challenges/easy/65_geglu/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/66_rgb_to_grayscale/starter/starter.jax.py
+++ b/challenges/easy/66_rgb_to_grayscale/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, width: int, height: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/68_sigmoid/starter/starter.jax.py
+++ b/challenges/easy/68_sigmoid/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# X is a tensor on GPU
+# X is a tensor on device
 @jax.jit
 def solve(X: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/7_color_inversion/starter/starter.jax.py
+++ b/challenges/easy/7_color_inversion/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# image is a tensor on the GPU
+# image is a tensor on device
 @jax.jit
 def solve(image: jax.Array, width: int, height: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/8_matrix_addition/starter/starter.jax.py
+++ b/challenges/easy/8_matrix_addition/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A, B are tensors on the GPU
+# A, B are tensors on device
 @jax.jit
 def solve(A: jax.Array, B: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/easy/9_1d_convolution/starter/starter.jax.py
+++ b/challenges/easy/9_1d_convolution/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input, kernel are tensors on the GPU
+# input, kernel are tensors on device
 @jax.jit
 def solve(input: jax.Array, kernel: jax.Array, input_size: int, kernel_size: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/hard/12_multi_head_attention/starter/starter.jax.py
+++ b/challenges/hard/12_multi_head_attention/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# Q, K, V are tensors on the GPU
+# Q, K, V are tensors on device
 @jax.jit
 def solve(Q: jax.Array, K: jax.Array, V: jax.Array, N: int, d_model: int, h: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/hard/14_multi_agent_sim/starter/starter.jax.py
+++ b/challenges/hard/14_multi_agent_sim/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# agents is a tensor on the GPU
+# agents is a tensor on device
 @jax.jit
 def solve(agents: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/hard/15_sorting/starter/starter.jax.py
+++ b/challenges/hard/15_sorting/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# data is a tensor on the GPU
+# data is a tensor on device
 @jax.jit
 def solve(data: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/hard/20_kmeans_clustering/starter/starter.jax.py
+++ b/challenges/hard/20_kmeans_clustering/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# data_x, data_y, initial_centroid_x, initial_centroid_y are tensors on the GPU
+# data_x, data_y, initial_centroid_x, initial_centroid_y are tensors on device
 @jax.jit
 def solve(
     data_x: jax.Array,

--- a/challenges/hard/36_radix_sort/starter/starter.jax.py
+++ b/challenges/hard/36_radix_sort/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/hard/39_Fast_Fourier_transform/starter/starter.jax.py
+++ b/challenges/hard/39_Fast_Fourier_transform/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# signal is a tensor on GPU
+# signal is a tensor on device
 @jax.jit
 def solve(signal: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/hard/46_bfs_shortest_path/starter/starter.jax.py
+++ b/challenges/hard/46_bfs_shortest_path/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# grid is a tensor on the GPU
+# grid is a tensor on device
 @jax.jit
 def solve(
     grid: jax.Array,

--- a/challenges/hard/53_casual_attention/starter/starter.jax.py
+++ b/challenges/hard/53_casual_attention/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# Q, K, V are tensors on the GPU
+# Q, K, V are tensors on device
 @jax.jit
 def solve(Q: jax.Array, K: jax.Array, V: jax.Array, M: int, d: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/hard/56_linear_attention/starter/starter.jax.py
+++ b/challenges/hard/56_linear_attention/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# Q, K, V are tensors on the GPU
+# Q, K, V are tensors on device
 @jax.jit
 def solve(Q: jax.Array, K: jax.Array, V: jax.Array, M: int, d: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/hard/59_sliding_window_attn/starter/starter.jax.py
+++ b/challenges/hard/59_sliding_window_attn/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# Q, K, V are tensors on the GPU
+# Q, K, V are tensors on device
 @jax.jit
 def solve(Q: jax.Array, K: jax.Array, V: jax.Array, M: int, d: int, window_size: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/hard/73_all_pairs_shortest_paths/starter/starter.jax.py
+++ b/challenges/hard/73_all_pairs_shortest_paths/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# dist is a tensor on the GPU
+# dist is a tensor on device
 @jax.jit
 def solve(dist: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/hard/74_gpt2_block/starter/starter.jax.py
+++ b/challenges/hard/74_gpt2_block/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# x, weights are tensors on GPU
+# x, weights are tensors on device
 @jax.jit
 def solve(x: jax.Array, weights: jax.Array, seq_len: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/hard/93_llama_transformer_block/starter/starter.jax.py
+++ b/challenges/hard/93_llama_transformer_block/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# x, weights, cos, sin are tensors on GPU
+# x, weights, cos, sin are tensors on device
 @jax.jit
 def solve(
     x: jax.Array,

--- a/challenges/medium/10_2d_convolution/starter/starter.jax.py
+++ b/challenges/medium/10_2d_convolution/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input, kernel are tensors on the GPU
+# input, kernel are tensors on device
 @jax.jit
 def solve(
     input: jax.Array,

--- a/challenges/medium/11_3d_convolution/starter/starter.jax.py
+++ b/challenges/medium/11_3d_convolution/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input, kernel are tensors on the GPU
+# input, kernel are tensors on device
 @jax.jit
 def solve(
     input: jax.Array,

--- a/challenges/medium/13_histogramming/starter/starter.jax.py
+++ b/challenges/medium/13_histogramming/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int, num_bins: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/16_prefix_sum/starter/starter.jax.py
+++ b/challenges/medium/16_prefix_sum/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/17_dot_product/starter/starter.jax.py
+++ b/challenges/medium/17_dot_product/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A, B are tensors on the GPU
+# A, B are tensors on device
 @jax.jit
 def solve(A: jax.Array, B: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/18_sparse_matrix_vector_multiplication/starter/starter.jax.py
+++ b/challenges/medium/18_sparse_matrix_vector_multiplication/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A, x are tensors on the GPU
+# A, x are tensors on device
 @jax.jit
 def solve(A: jax.Array, x: jax.Array, M: int, N: int, nnz: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/22_gemm/starter/starter.jax.py
+++ b/challenges/medium/22_gemm/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A, B are tensors on the GPU
+# A, B are tensors on device
 @jax.jit
 def solve(
     A: jax.Array, B: jax.Array, M: int, N: int, K: int, alpha: float, beta: float

--- a/challenges/medium/25_categorical_cross_entropy_loss/starter/starter.jax.py
+++ b/challenges/medium/25_categorical_cross_entropy_loss/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# logits, true_labels are tensors on the GPU
+# logits, true_labels are tensors on device
 @jax.jit
 def solve(logits: jax.Array, true_labels: jax.Array, N: int, C: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/27_mean_squared_error/starter/starter.jax.py
+++ b/challenges/medium/27_mean_squared_error/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# predictions, targets are tensors on the GPU
+# predictions, targets are tensors on device
 @jax.jit
 def solve(predictions: jax.Array, targets: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/28_gaussian_blur/starter/starter.jax.py
+++ b/challenges/medium/28_gaussian_blur/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input, kernel are tensors on the GPU
+# input, kernel are tensors on device
 @jax.jit
 def solve(
     input: jax.Array,

--- a/challenges/medium/29_top_k_selection/starter/starter.jax.py
+++ b/challenges/medium/29_top_k_selection/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int, k: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/30_batched_matrix_multiplication/starter/starter.jax.py
+++ b/challenges/medium/30_batched_matrix_multiplication/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A, B are tensors on the GPU
+# A, B are tensors on device
 @jax.jit
 def solve(A: jax.Array, B: jax.Array, BATCH: int, M: int, N: int, K: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/32_int8_quantized_matmul/starter/starter.jax.py
+++ b/challenges/medium/32_int8_quantized_matmul/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A, B are tensors on the GPU
+# A, B are tensors on device
 @jax.jit
 def solve(
     A: jax.Array,

--- a/challenges/medium/33_ordinary_least_squares/starter/starter.jax.py
+++ b/challenges/medium/33_ordinary_least_squares/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# X, y are tensors on the GPU
+# X, y are tensors on device
 @jax.jit
 def solve(X: jax.Array, y: jax.Array, n_samples: int, n_features: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/34_logistic_regression/starter/starter.jax.py
+++ b/challenges/medium/34_logistic_regression/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# X, y are tensors on the GPU
+# X, y are tensors on device
 @jax.jit
 def solve(X: jax.Array, y: jax.Array, n_samples: int, n_features: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/35_monte_carlo_integration/starter/starter.jax.py
+++ b/challenges/medium/35_monte_carlo_integration/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# y_samples is a tensor on the GPU
+# y_samples is a tensor on device
 @jax.jit
 def solve(y_samples: jax.Array, a: float, b: float, n_samples: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/37_matrix_power/starter/starter.jax.py
+++ b/challenges/medium/37_matrix_power/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int, P: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/38_nearest_neighbor/starter/starter.jax.py
+++ b/challenges/medium/38_nearest_neighbor/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# points is a tensor on the GPU
+# points is a tensor on device
 @jax.jit
 def solve(points: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/40_batch_normalization/starter/starter.jax.py
+++ b/challenges/medium/40_batch_normalization/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input, gamma, beta are tensors on the GPU
+# input, gamma, beta are tensors on device
 @jax.jit
 def solve(
     input: jax.Array, gamma: jax.Array, beta: jax.Array, N: int, C: int, eps: float

--- a/challenges/medium/42_2d_max_pooling/starter/starter.jax.py
+++ b/challenges/medium/42_2d_max_pooling/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(
     input: jax.Array, N: int, C: int, H: int, W: int, kernel_size: int, stride: int, padding: int

--- a/challenges/medium/43_count_array_element/starter/starter.jax.py
+++ b/challenges/medium/43_count_array_element/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int, K: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/44_count_2d_array_element/starter/starter.jax.py
+++ b/challenges/medium/44_count_2d_array_element/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int, M: int, K: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/45_count_3d_array_element/starter/starter.jax.py
+++ b/challenges/medium/45_count_3d_array_element/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int, M: int, K: int, P: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/47_subarray_sum/starter/starter.jax.py
+++ b/challenges/medium/47_subarray_sum/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int, S: int, E: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/48_2d_subarray_sum/starter/starter.jax.py
+++ b/challenges/medium/48_2d_subarray_sum/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(
     input: jax.Array, N: int, M: int, S_ROW: int, E_ROW: int, S_COL: int, E_COL: int

--- a/challenges/medium/49_3d_subarray_sum/starter/starter.jax.py
+++ b/challenges/medium/49_3d_subarray_sum/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(
     input: jax.Array,

--- a/challenges/medium/4_reduction/starter/starter.jax.py
+++ b/challenges/medium/4_reduction/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/50_rms_normalization/starter/starter.jax.py
+++ b/challenges/medium/50_rms_normalization/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input, gamma, beta are tensors on the GPU
+# input, gamma, beta are tensors on device
 @jax.jit
 def solve(input: jax.Array, gamma: jax.Array, beta: jax.Array, N: int, eps: float) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/51_max_subarray_sum/starter/starter.jax.py
+++ b/challenges/medium/51_max_subarray_sum/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int, window_size: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/55_attn_w_linear_bias/starter/starter.jax.py
+++ b/challenges/medium/55_attn_w_linear_bias/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# Q, K, V are tensors on the GPU
+# Q, K, V are tensors on device
 @jax.jit
 def solve(
     Q: jax.Array, K: jax.Array, V: jax.Array, M: int, N: int, d: int, alpha: float

--- a/challenges/medium/57_fp16_batched_matmul/starter/starter.jax.py
+++ b/challenges/medium/57_fp16_batched_matmul/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A, B are tensors on the GPU
+# A, B are tensors on device
 @jax.jit
 def solve(A: jax.Array, B: jax.Array, BATCH: int, M: int, N: int, K: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/58_fp16_dot_product/starter/starter.jax.py
+++ b/challenges/medium/58_fp16_dot_product/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A, B are tensors on the GPU
+# A, B are tensors on device
 @jax.jit
 def solve(A: jax.Array, B: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/5_softmax/starter/starter.jax.py
+++ b/challenges/medium/5_softmax/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/61_rope_embedding/starter/starter.jax.py
+++ b/challenges/medium/61_rope_embedding/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# Q, cos, sin are tensors on the GPU
+# Q, cos, sin are tensors on device
 @jax.jit
 def solve(Q: jax.Array, cos: jax.Array, sin: jax.Array, M: int, D: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/64_weight_dequantization/starter/starter.jax.py
+++ b/challenges/medium/64_weight_dequantization/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# X, S are tensors on the GPU
+# X, S are tensors on device
 @jax.jit
 def solve(X: jax.Array, S: jax.Array, M: int, N: int, TILE_SIZE: int) -> jax.Array:
     # return output tensor Y directly

--- a/challenges/medium/67_moe_topk_gating/starter/starter.jax.py
+++ b/challenges/medium/67_moe_topk_gating/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# logits is a tensor on the GPU
+# logits is a tensor on device
 @jax.jit
 def solve(logits: jax.Array, M: int, E: int, k: int) -> tuple[jax.Array, jax.Array]:
     pass

--- a/challenges/medium/69_jacobi_stencil_2d/starter/starter.jax.py
+++ b/challenges/medium/69_jacobi_stencil_2d/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# input is a tensor on the GPU
+# input is a tensor on device
 @jax.jit
 def solve(input: jax.Array, rows: int, cols: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/6_softmax_attention/starter/starter.jax.py
+++ b/challenges/medium/6_softmax_attention/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# Q, K, V are tensors on the GPU
+# Q, K, V are tensors on device
 @jax.jit
 def solve(Q: jax.Array, K: jax.Array, V: jax.Array, M: int, N: int, d: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/70_segmented_prefix_sum/starter/starter.jax.py
+++ b/challenges/medium/70_segmented_prefix_sum/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# values, flags are tensors on the GPU
+# values, flags are tensors on device
 @jax.jit
 def solve(values: jax.Array, flags: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/71_parallel_merge/starter/starter.jax.py
+++ b/challenges/medium/71_parallel_merge/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A, B are tensors on GPU
+# A, B are tensors on device
 @jax.jit
 def solve(A: jax.Array, B: jax.Array, M: int, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/72_stream_compaction/starter/starter.jax.py
+++ b/challenges/medium/72_stream_compaction/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A is a tensor on GPU
+# A is a tensor on device
 @jax.jit
 def solve(A: jax.Array, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/75_sparse_matrix_dense_matrix_multiplication/starter/starter.jax.py
+++ b/challenges/medium/75_sparse_matrix_dense_matrix_multiplication/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# A, B are tensors on GPU
+# A, B are tensors on device
 @jax.jit
 def solve(A: jax.Array, B: jax.Array, M: int, N: int, K: int, nnz: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/76_adder_transformer/starter/starter.jax.py
+++ b/challenges/medium/76_adder_transformer/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# prompts, weights are tensors on GPU
+# prompts, weights are tensors on device
 @jax.jit
 def solve(prompts: jax.Array, weights: jax.Array, batch_size: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/78_2d_fft/starter/starter.jax.py
+++ b/challenges/medium/78_2d_fft/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# signal is a tensor on GPU
+# signal is a tensor on device
 @jax.jit
 def solve(signal: jax.Array, M: int, N: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/80_grouped_query_attention/starter/starter.jax.py
+++ b/challenges/medium/80_grouped_query_attention/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# Q, K, V are tensors on GPU
+# Q, K, V are tensors on device
 @jax.jit
 def solve(
     Q: jax.Array,

--- a/challenges/medium/81_int4_matmul/starter/starter.jax.py
+++ b/challenges/medium/81_int4_matmul/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# x, w_q, scales are tensors on GPU
+# x, w_q, scales are tensors on device
 @jax.jit
 def solve(
     x: jax.Array,

--- a/challenges/medium/82_linear_recurrence/starter/starter.jax.py
+++ b/challenges/medium/82_linear_recurrence/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# a, x are tensors on GPU
+# a, x are tensors on device
 @jax.jit
 def solve(a: jax.Array, x: jax.Array, B: int, L: int) -> jax.Array:
     # return output tensor directly

--- a/challenges/medium/84_swiglu_mlp_block/starter/starter.jax.py
+++ b/challenges/medium/84_swiglu_mlp_block/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# x, W_gate, W_up, W_down are tensors on GPU
+# x, W_gate, W_up, W_down are tensors on device
 @jax.jit
 def solve(
     x: jax.Array,

--- a/challenges/medium/85_lora_linear/starter/starter.jax.py
+++ b/challenges/medium/85_lora_linear/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# x, W, A, B are tensors on GPU
+# x, W, A, B are tensors on device
 @jax.jit
 def solve(
     x: jax.Array,

--- a/challenges/medium/87_speculative_decoding_verification/starter/starter.jax.py
+++ b/challenges/medium/87_speculative_decoding_verification/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# draft_tokens, draft_probs, target_probs, uniform_samples are tensors on GPU
+# draft_tokens, draft_probs, target_probs, uniform_samples are tensors on device
 @jax.jit
 def solve(
     draft_tokens: jax.Array,

--- a/challenges/medium/90_causal_depthwise_conv1d/starter/starter.jax.py
+++ b/challenges/medium/90_causal_depthwise_conv1d/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# x, weight, bias are tensors on GPU
+# x, weight, bias are tensors on device
 @jax.jit
 def solve(
     x: jax.Array, weight: jax.Array, bias: jax.Array, B: int, L: int, D: int, K: int

--- a/challenges/medium/92_decaying_causal_attention/starter/starter.jax.py
+++ b/challenges/medium/92_decaying_causal_attention/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# Q, K, V are tensors on GPU
+# Q, K, V are tensors on device
 @jax.jit
 def solve(
     Q: jax.Array,

--- a/challenges/medium/94_ssm_selective_scan/starter/starter.jax.py
+++ b/challenges/medium/94_ssm_selective_scan/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# u, delta, A, B, C, skip are tensors on GPU
+# u, delta, A, B, C, skip are tensors on device
 @jax.jit
 def solve(
     u: jax.Array,

--- a/challenges/medium/96_int8_kv_cache_attention/starter/starter.jax.py
+++ b/challenges/medium/96_int8_kv_cache_attention/starter/starter.jax.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 
 
-# Q, K_int8, V_int8, k_scale, v_scale are tensors on GPU
+# Q, K_int8, V_int8, k_scale, v_scale are tensors on device
 @jax.jit
 def solve(
     Q: jax.Array,


### PR DESCRIPTION
## Summary
- Normalize all JAX starter parameter comments from GPU-specific phrasing to the device-neutral "on device", since the JAX/XLA reference path targets TPU as well as GPU.
- Sweeps all four phrasings that existed across the 86 JAX starters: `are tensors on GPU`, `are tensors on the GPU`, `is a tensor on GPU`, `is a tensor on the GPU` → `... on device`.
- Update `CLAUDE.md`'s comment-template table and starter checklist so new JAX starters follow this convention.

## Scope
- Only `.jax.py` starters changed. PyTorch/Triton/CuTe ("tensors on the GPU") and CUDA/Mojo ("device pointers") are intentionally left as-is.
- No behavioral change — comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)