### PR TITLE
Add challenge structure validator

### DIFF
--- a/.github/workflows/check-duplicated-index.yml
+++ b/.github/workflows/check-duplicated-index.yml
@@ -1,4 +1,4 @@
-name: Check Challenge Indexes
+name: Validate Challenge Structure
 
 on:
   pull_request:
@@ -18,21 +18,5 @@ jobs:
       with:
         python-version: '3.12'
 
-    - name: Check for duplicate indexes
-      run: |
-        python - << 'EOF'
-        import os
-        import collections
-
-        challenges_dir = "challenges"
-
-        questions = collections.defaultdict(list)
-        for folder in os.listdir(challenges_dir):
-            folder_path = os.path.join(challenges_dir, folder)
-            for question in os.listdir(folder_path):
-                idx = question.split("_")[0]
-                questions[idx].append(question)
-                if len(questions[idx]) > 1:
-                    print(f"PR duplicated found: \n {questions[idx]}.")
-                    exit(1)
-        EOF
+    - name: Validate challenge structure
+      run: python scripts/validate_challenges.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,20 +19,27 @@ Each challenge should include:
 
 ```
 challenges/<difficulty>/<number>_<name>/
-├── challenge.html          # Problem description
-├── challenge.py           # Reference implementation and metadata
-└── starter/              # Starter templates
-    ├── starter.cu           # CUDA 
-    ├── starter.mojo         # Mojo 
-    ├── starter.pytorch.py   # PyTorch 
-    ├── starter.tinygrad.py  # TinyGrad 
-    └── starter.triton.py    # Triton 
+|-- challenge.html          # Problem description
+|-- challenge.py            # Reference implementation and metadata
+`-- starter/                # Starter templates
+    |-- starter.cu          # CUDA
+    |-- starter.cute.py     # CuTe
+    |-- starter.jax.py      # JAX
+    |-- starter.mojo        # Mojo
+    |-- starter.pytorch.py  # PyTorch
+    `-- starter.triton.py   # Triton
 ```
 
 ### Requirements
 - Clear problem description with 1 or more examples
 - Starter templates should follow the format of existing starter templates
 - Follow existing challenge patterns
+
+Validate challenge structure before opening a pull request:
+
+```bash
+python scripts/validate_challenges.py
+```
 
 ### Starter Template Guidelines
 - **Comments**: Match the format of existing challenges
@@ -99,43 +106,42 @@ The CI will automatically check all code submissions. Fix any linting errors bef
 1. **Fork the repository**
 2. **Create a feature branch**: `git checkout -b challenge/new-challenge-name`
 3. **Add your challenge** with all required files
-5. **Submit a pull request** with a clear description
+4. **Submit a pull request** with a clear description
 
 ## Getting Help
 
 - Open an issue for questions
 - Check existing challenges for examples
 
-Thank you for helping improve LeetGPU! 
+Thank you for helping improve LeetGPU!
 
 ## Contributor Terms
 
 By submitting code, documentation, or any other content to this repository
-(“Contribution”), you confirm that:
+("Contribution"), you confirm that:
 
-1. **Ownership**  
+1. **Ownership**
    You are the sole author of the Contribution, or have obtained all
    necessary rights and permissions to grant the licenses below.
 
-2. **Dual License to the Project**  
-   You grant AlphaGPU and its downstream users **two** non‑exclusive,
-   worldwide, royalty‑free licenses to your Contribution:
+2. **Dual License to the Project**
+   You grant AlphaGPU and its downstream users **two** non-exclusive,
+   worldwide, royalty-free licenses to your Contribution:
 
-   **a.** Under the repository’s public license,  
-   Creative Commons Attribution‑NonCommercial‑NoDerivatives 4.0  
-   (“CC BY‑NC‑ND”), for all public distribution.
+   **a.** Under the repository's public license,
+   Creative Commons Attribution-NonCommercial-NoDerivatives 4.0
+   ("CC BY-NC-ND"), for all public distribution.
 
-   **b.** Under a commercial‑friendly license to AlphaGPU itself:  
-   – **Grant:** AlphaGPU may reproduce, distribute, adapt, sublicense,  
-     and create derivative works of your Contribution for any purpose,  
-     including commercial use.  
-   – **No further conditions:** AlphaGPU need not attribute further or  
+   **b.** Under a commercial-friendly license to AlphaGPU itself:
+   - **Grant:** AlphaGPU may reproduce, distribute, adapt, sublicense,
+     and create derivative works of your Contribution for any purpose,
+     including commercial use.
+   - **No further conditions:** AlphaGPU need not attribute further or
      seek additional permission beyond this agreement.
 
-3. **No Additional Restrictions**  
+3. **No Additional Restrictions**
    You may **not** impose any further terms on your Contribution that
    conflict with the licenses granted above.
 
-4. **Pull Request = Acceptance**  
+4. **Pull Request = Acceptance**
    Submitting a Pull Request constitutes acceptance of these terms.
-

--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing new challe
 
 ## License
 
-This problem set is licensed under [CC BY‑NC‑ND 4.0 license](LICENSE).
+This problem set is licensed under the [CC BY-NC-ND 4.0 license](LICENSE).
 
-© 2025 AlphaGPU, LLC. Commercial use, redistribution, or derivative use is prohibited.
+Copyright 2025 AlphaGPU, LLC. Commercial use, redistribution, or derivative use is prohibited.

--- a/scripts/validate_challenges.py
+++ b/scripts/validate_challenges.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+Validate challenge structure and metadata without importing challenge dependencies.
+
+This script is intentionally AST-based so it can run in CI without PyTorch, CUDA,
+JAX, or other challenge runtime dependencies installed.
+"""
+
+import argparse
+import ast
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+DIFFICULTIES = ("easy", "medium", "hard")
+REQUIRED_FILES = ("challenge.py", "challenge.html")
+REQUIRED_METADATA = ("name", "atol", "rtol", "num_gpus", "access_tier")
+REQUIRED_METHODS = (
+    "reference_impl",
+    "get_solve_signature",
+    "generate_example_test",
+    "generate_functional_test",
+    "generate_performance_test",
+)
+SUPPORTED_STARTERS = {
+    "starter.cu",
+    "starter.cute.py",
+    "starter.jax.py",
+    "starter.mojo",
+    "starter.pytorch.py",
+    "starter.triton.py",
+}
+CHALLENGE_ID_RE = re.compile(r"^(?P<id>\d+)_")
+CHALLENGE_DIR_RE = re.compile(r"^(?P<id>\d+)_[a-z0-9_]+$")
+
+
+@dataclass(frozen=True)
+class Issue:
+    severity: str
+    path: Path
+    message: str
+
+    def format(self, root: Path) -> str:
+        try:
+            display_path = self.path.relative_to(root)
+        except ValueError:
+            display_path = self.path
+        return f"{self.severity}: {display_path}: {self.message}"
+
+
+def iter_challenge_dirs(challenges_root: Path) -> Iterable[Path]:
+    for difficulty in DIFFICULTIES:
+        difficulty_dir = challenges_root / difficulty
+        if not difficulty_dir.is_dir():
+            continue
+        yield from sorted(path for path in difficulty_dir.iterdir() if path.is_dir())
+
+
+def get_challenge_id(challenge_dir: Path) -> int | None:
+    match = CHALLENGE_ID_RE.match(challenge_dir.name)
+    if not match:
+        return None
+    return int(match.group("id"))
+
+
+def find_challenge_class(challenge_py: Path) -> ast.ClassDef | None:
+    try:
+        tree = ast.parse(challenge_py.read_text(encoding="utf-8"), filename=str(challenge_py))
+    except SyntaxError:
+        return None
+
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "Challenge":
+            return node
+    return None
+
+
+def class_assignments(class_node: ast.ClassDef) -> set[str]:
+    assignments = set()
+    for node in class_node.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    assignments.add(target.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            assignments.add(node.target.id)
+    return assignments
+
+
+def class_methods(class_node: ast.ClassDef) -> set[str]:
+    return {
+        node.name
+        for node in class_node.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def validate_challenge_dir(challenge_dir: Path, strict_starters: bool) -> list[Issue]:
+    issues = []
+
+    if not CHALLENGE_DIR_RE.match(challenge_dir.name):
+        severity = "ERROR" if get_challenge_id(challenge_dir) is None else "WARN"
+        issues.append(
+            Issue(
+                severity,
+                challenge_dir,
+                "directory name should match '<number>_<lowercase_slug>'",
+            )
+        )
+
+    for filename in REQUIRED_FILES:
+        if not (challenge_dir / filename).is_file():
+            issues.append(Issue("ERROR", challenge_dir, f"missing required file: {filename}"))
+
+    challenge_py = challenge_dir / "challenge.py"
+    if challenge_py.is_file():
+        challenge_class = find_challenge_class(challenge_py)
+        if challenge_class is None:
+            issues.append(Issue("ERROR", challenge_py, "missing parseable Challenge class"))
+        else:
+            assignments = class_assignments(challenge_class)
+            methods = class_methods(challenge_class)
+
+            for name in REQUIRED_METADATA:
+                if name not in assignments:
+                    issues.append(Issue("ERROR", challenge_py, f"missing metadata: {name}"))
+
+            for name in REQUIRED_METHODS:
+                if name not in methods:
+                    issues.append(Issue("ERROR", challenge_py, f"missing method: {name}"))
+
+    starter_dir = challenge_dir / "starter"
+    if not starter_dir.is_dir():
+        issues.append(Issue("ERROR", challenge_dir, "missing starter directory"))
+        return issues
+
+    starter_files = {path.name for path in starter_dir.iterdir() if path.is_file()}
+    unknown_starters = sorted(starter_files - SUPPORTED_STARTERS)
+    missing_starters = sorted(SUPPORTED_STARTERS - starter_files)
+
+    for filename in unknown_starters:
+        issues.append(Issue("ERROR", starter_dir / filename, "unsupported starter filename"))
+
+    if missing_starters:
+        severity = "ERROR" if strict_starters else "WARN"
+        issues.append(
+            Issue(
+                severity,
+                starter_dir,
+                "missing starter files: " + ", ".join(missing_starters),
+            )
+        )
+
+    return issues
+
+
+def validate_unique_ids(challenge_dirs: Sequence[Path]) -> list[Issue]:
+    by_id: dict[int, list[Path]] = defaultdict(list)
+    for challenge_dir in challenge_dirs:
+        challenge_id = get_challenge_id(challenge_dir)
+        if challenge_id is not None:
+            by_id[challenge_id].append(challenge_dir)
+
+    issues = []
+    for challenge_id, paths in sorted(by_id.items()):
+        if len(paths) > 1:
+            joined_paths = ", ".join(str(path) for path in paths)
+            issues.append(
+                Issue("ERROR", paths[0], f"duplicate challenge id {challenge_id}: {joined_paths}")
+            )
+    return issues
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate LeetGPU challenge structure.")
+    parser.add_argument(
+        "--challenges-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "challenges",
+        help="Path to the challenges directory.",
+    )
+    parser.add_argument(
+        "--strict-starters",
+        action="store_true",
+        help="Treat missing starter templates as errors instead of warnings.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    challenges_root = args.challenges_root.resolve()
+    repo_root = challenges_root.parent
+
+    if not challenges_root.is_dir():
+        print(f"ERROR: {challenges_root}: challenges root does not exist", file=sys.stderr)
+        return 1
+
+    challenge_dirs = list(iter_challenge_dirs(challenges_root))
+    issues = validate_unique_ids(challenge_dirs)
+    for challenge_dir in challenge_dirs:
+        issues.extend(validate_challenge_dir(challenge_dir, args.strict_starters))
+
+    for issue in issues:
+        stream = sys.stderr if issue.severity == "ERROR" else sys.stdout
+        print(issue.format(repo_root), file=stream)
+
+    error_count = sum(issue.severity == "ERROR" for issue in issues)
+    warning_count = sum(issue.severity == "WARN" for issue in issues)
+    print(
+        f"Validated {len(challenge_dirs)} challenges: "
+        f"{error_count} errors, {warning_count} warnings"
+    )
+
+    return 1 if error_count else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a reusable challenge validation script and wires it into CI.

The new `scripts/validate_challenges.py` checks challenge structure without importing runtime dependencies like PyTorch, CUDA, or JAX. It uses Python AST parsing to validate challenge metadata and required methods, making it safe to run in lightweight CI environments.

## What Changed

- Added `scripts/validate_challenges.py`
- Replaced the inline duplicate-index GitHub Action logic with the validator
- Documented the validation command in `CONTRIBUTING.md`
- Cleaned up minor README / CONTRIBUTING encoding and formatting issues

## Validation Covered

The script checks:

- required files: `challenge.py`, `challenge.html`
- duplicate challenge IDs
- challenge directory naming
- required `Challenge` metadata fields
- required challenge methods
- supported starter filenames
- missing starter templates as warnings by default

## Testing

Ran locally:

```bash
python scripts/validate_challenges.py
python -m black --check --diff scripts/validate_challenges.py
python -m py_compile scripts/validate_challenges.py
git diff --check