### PR TITLE
Fix GEMM JAX starter: add missing C parameter to solve()

### DIFF
--- a/challenges/medium/22_gemm/starter/starter.jax.py
+++ b/challenges/medium/22_gemm/starter/starter.jax.py
@@ -2,10 +2,17 @@ import jax
 import jax.numpy as jnp
 
 
-# A, B are tensors on device
+# A, B, C are tensors on device
 @jax.jit
 def solve(
-    A: jax.Array, B: jax.Array, M: int, N: int, K: int, alpha: float, beta: float
+    A: jax.Array,
+    B: jax.Array,
+    C: jax.Array,
+    M: int,
+    N: int,
+    K: int,
+    alpha: float,
+    beta: float,
 ) -> jax.Array:
     # return output tensor directly
     pass


### PR DESCRIPTION
Fixes #301.

The JAX starter's `solve()` was missing the `C` accumulator tensor that
the harness passes (`alpha*A@B + beta*C`), causing:

`TypeError: solve() takes 7 positional arguments but 8 were given`

Brought the signature in line with the PyTorch/Triton starters for this
challenge and the existing pattern in `94_ssm_selective_scan`'s JAX
starter. Verified with `pre-commit run --all-files` (black/isort/flake8/
clang-format all pass).